### PR TITLE
Allow the tsconfig file to be configured via the command line

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
     },
     "author": "Scott Mikula <mikula@gmail.com>",
     "dependencies": {
+        "commander": "^2.11.0",
         "glob": "^7.1.2",
         "minimatch": "^3.0.4",
         "typescript": ">=2.4.0"
     },
     "devDependencies": {
+        "@types/commander": "^2.11.0",
         "@types/jest": "^21.1.2",
         "@types/node": "^7.0.4",
         "jest": "^21.2.1"

--- a/src/TypeScriptProgram.ts
+++ b/src/TypeScriptProgram.ts
@@ -10,7 +10,7 @@ export default class TypeScriptProgram {
     constructor(configFile: string) {
         // Parse the config file
         const projectPath = path.dirname(path.resolve(configFile));
-        const { config } = ts.readConfigFile(configFile, ts.sys.readFile);
+        const config = readConfigFile(configFile);
         const parsedConfig = ts.parseJsonConfigFileContent(config, ts.sys, projectPath);
         this.compilerOptions = parsedConfig.options;
 
@@ -49,4 +49,14 @@ export default class TypeScriptProgram {
 
         return resolvedFile.resolvedModule && resolvedFile.resolvedModule.resolvedFileName;
     }
+}
+
+function readConfigFile(configFile: string) {
+    const { config, error } = ts.readConfigFile(configFile, ts.sys.readFile);
+
+    if (error) {
+        throw new Error('Error reading project file: ' + error.messageText);
+    }
+
+    return config;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,12 @@
+import * as commander from 'commander';
 import { run } from './runner';
+
+// Read the package version from package.json
+let packageVersion = require('../package').version;
+
+commander
+    .version(packageVersion)
+    .option('-p, --project <string>', 'tsconfig.json file')
+    .parse(process.argv);
 
 run();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,15 @@
 import * as commander from 'commander';
+import Options from './types/Options';
 import { run } from './runner';
 
 // Read the package version from package.json
-let packageVersion = require('../package').version;
+const packageVersion = require('../package').version;
 
-commander
+// Parse command line options
+const options = commander
     .version(packageVersion)
     .option('-p, --project <string>', 'tsconfig.json file')
-    .parse(process.argv);
+    .parse(process.argv) as Options;
 
-run();
+// Run good-fences
+run(options);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,8 +1,10 @@
+import Options from './types/Options';
 import validateFile from './validateFile';
 import TypeScriptProgram from './TypeScriptProgram';
 
-export function run() {
-    let tsProgram = new TypeScriptProgram('tsconfig.json');
+export function run(options: Options) {
+    const project = options.project || 'tsconfig.json';
+    let tsProgram = new TypeScriptProgram(project);
     let files = tsProgram.getSourceFiles();
     files.forEach(file => {
         validateFile(file, tsProgram);

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -1,0 +1,3 @@
+export default interface Options {
+    project?: string;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,19 @@
 # yarn lockfile v1
 
 
+"@types/commander@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@types/commander/-/commander-2.11.0.tgz#7fc765ccad14827e2babd6a99583359ff3e40563"
+  dependencies:
+    "@types/node" "*"
+
 "@types/jest@^21.1.2":
   version "21.1.2"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-21.1.2.tgz#05ebfa64817b626694ced56745a7949281981048"
+
+"@types/node@*":
+  version "8.0.46"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.46.tgz#6e1766b2d0ed06631d5b5f87bb8e72c8dbb6888e"
 
 "@types/node@^7.0.4":
   version "7.0.43"
@@ -465,6 +475,10 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
 concat-map@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
* Add commander for CLI option parsing
* Accept a `--project` option to specify the tsconfig file (defaulting to tsconfig.json in the current working directory)
* Report errors from reading the project file (such as if it does not exist)