### PR TITLE
Allow for reporting errors programmatically

### DIFF
--- a/src/reportError.ts
+++ b/src/reportError.ts
@@ -1,3 +1,13 @@
+let errorReporter = logToConsole;
+
 export default function reportError(message: string) {
-    console.error(`[good-fences] Error: ${message}`);
+    errorReporter(message);
+}
+
+export function setErrorReporter(onError: (message: string) => void) {
+    errorReporter = onError;
+}
+
+function logToConsole(message: string) {
+    console.error(`Error: ${message}`);
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,9 +1,16 @@
 import Options from './types/Options';
+import { setErrorReporter } from './reportError';
 import validateFile from './validateFile';
 import TypeScriptProgram from './TypeScriptProgram';
 
 export function run(options: Options) {
+    // Apply options
     const project = options.project || 'tsconfig.json';
+    if (options.onError) {
+        setErrorReporter(options.onError);
+    }
+
+    // Run validation
     let tsProgram = new TypeScriptProgram(project);
     let files = tsProgram.getSourceFiles();
     files.forEach(file => {

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -1,3 +1,4 @@
 export default interface Options {
     project?: string;
+    onError?: (message: string) => void;
 };


### PR DESCRIPTION
With this change it is possible to pass in an `onError` callback on the options object.  If provided, errors will be reported via the callback instead of being written to the console.