### PR TITLE
Use NormalizedOptions internally

### DIFF
--- a/src/getOptions.ts
+++ b/src/getOptions.ts
@@ -1,18 +1,23 @@
 import Options from './types/Options';
+import NormalizedOptions from './types/NormalizedOptions';
 import normalizePath from './normalizePath';
 
-let options: Options;
+let options: NormalizedOptions;
 
 export default function getOptions() {
     return options;
 }
 
 export function setOptions(providedOptions: Options) {
-    options = providedOptions;
-
     // Normalize and apply defaults
-    options.rootDir = normalizePath(options.rootDir || process.cwd());
-    options.project = options.project
-        ? normalizePath(options.project)
-        : normalizePath(options.rootDir, 'tsconfig.json');
+    const rootDir = normalizePath(providedOptions.rootDir || process.cwd());
+    const project = providedOptions.project
+        ? normalizePath(providedOptions.project)
+        : normalizePath(rootDir, 'tsconfig.json');
+
+    options = {
+        project,
+        rootDir,
+        onError: providedOptions.onError,
+    };
 }

--- a/src/types/NormalizedOptions.ts
+++ b/src/types/NormalizedOptions.ts
@@ -1,0 +1,7 @@
+import NormalizedPath from './NormalizedPath';
+
+export default interface NormalizedOptions {
+    project: NormalizedPath;
+    rootDir: NormalizedPath;
+    onError?: (message: string) => void;
+};

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -1,7 +1,5 @@
-import NormalizedPath from './NormalizedPath';
-
 export default interface Options {
-    project?: NormalizedPath;
-    rootDir?: NormalizedPath;
+    project?: string;
+    rootDir?: string;
     onError?: (message: string) => void;
 };


### PR DESCRIPTION
The previous path handling changes (#14) end up leaking the `NormalizedPath` type.  Consumers should be allowed to just pass simple strings in for those paths.  This change introduces a new `NormalizedOptions` type that is used for options internally, separate from the `Options` object the consumer passes in.