### PR TITLE
Properly handle exports of .d.ts files

### DIFF
--- a/src/fileMatchesConfigGlob.ts
+++ b/src/fileMatchesConfigGlob.ts
@@ -14,9 +14,12 @@ export default function fileMatchesConfigGlob(
     }
 
     // Remove the file extension before matching
-    importFile = <NormalizedPath>importFile.substr(
-        0,
-        importFile.length - path.extname(importFile).length
-    );
+    importFile = removeFileExtension(importFile);
     return minimatch(importFile, normalizePath(configPath, key));
+}
+
+function removeFileExtension(filePath: NormalizedPath): NormalizedPath {
+    // Special case for .d.ts files
+    let extension = filePath.endsWith('.d.ts') ? '.d.ts' : path.extname(filePath);
+    return <NormalizedPath>filePath.slice(0, -extension.length);
 }

--- a/test/fileMatchesConfigGlobTests.ts
+++ b/test/fileMatchesConfigGlobTests.ts
@@ -3,6 +3,7 @@ import normalizePath from '../src/normalizePath';
 import fileMatchesConfigGlob from '../src/fileMatchesConfigGlob';
 
 const importFilePath = normalizePath(normalize('a\\b\\c\\d\\e\\file.ts'));
+const dtsImportFilePath = normalizePath(normalize('a\\b\\c\\d\\e\\file.d.ts'));
 const configPath = normalizePath(normalize('a\\b'));
 
 describe('fileMatchesConfigGlob', () => {
@@ -31,6 +32,12 @@ describe('fileMatchesConfigGlob', () => {
     it('matches path wildcards', () => {
         let key = normalize('c\\**\\file');
         let match = fileMatchesConfigGlob(importFilePath, configPath, key);
+        expect(match).toBe(true);
+    });
+
+    it('matches a d.ts file', () => {
+        let key = normalize('c\\d\\e\\file');
+        let match = fileMatchesConfigGlob(dtsImportFilePath, configPath, key);
         expect(match).toBe(true);
     });
 });


### PR DESCRIPTION
This resolves #19.  The problem was that we were naively determining the file extension by looking at the last dot; we needed a special case for .d.ts files.