### PR TITLE
Set process.exitCode to 1 if any files failed

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,5 +12,17 @@ const options = commander
     .option('-r, --rootDir <string>', 'root directory of the project')
     .parse(process.argv) as Options;
 
+let hadError = false;
+
 // Run good-fences
-run(options);
+run({
+    ...options,
+    onError() {
+        hadError = true;
+    },
+});
+
+process.exitCode = hadError
+    ? 1
+    : 0;
+


### PR DESCRIPTION
It's not enough to just console.error, as `npm run` only considers a script to fail if it sets `process.exitCode` to a non-zero value. This pipes a boolean result for each file from `validateImportIsAccessible.ts` through `validateFile.ts` to `runner.ts`. `run` now returns an object containing a `string[]` of the failing file paths.

Returning a `string[]` is a little restrictive in that the format would have to be changed to something different if, in the future, `run` were to also return the failing imports. I can change to something more complex if you'd like.

Also, `run`/`cli` don't have tests yet, so I didn't add any. Would you like me to?

Pinging @smikula because you're not watching the repository 😉 

Fixes #27 