### PR TITLE
Fix console error reporting via CLI runner

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,12 +17,11 @@ let hadError = false;
 // Run good-fences
 run({
     ...options,
-    onError() {
+    onError(message) {
+        console.error(`Error: ${message}`);
         hadError = true;
     },
 });
 
-process.exitCode = hadError
-    ? 1
-    : 0;
-
+// Indicate success or failure via the exit code
+process.exitCode = hadError ? 1 : 0;

--- a/src/reportError.ts
+++ b/src/reportError.ts
@@ -1,9 +1,7 @@
 import getOptions from './getOptions';
 
 export default function reportError(message: string) {
-    (getOptions().onError || logToConsole)(message);
-}
-
-function logToConsole(message: string) {
-    console.error(`Error: ${message}`);
+    if (getOptions().onError) {
+        getOptions().onError(message);
+    }
 }


### PR DESCRIPTION
The previous PR overrode `onError` which prevented errors from getting written to the console during a CLI run.