### PR TITLE
Support restricting internal dependencies

### DIFF
--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -5,4 +5,5 @@ export default interface Config {
     tags?: string[];
     exports?: { [files: string]: string | string[] };
     dependencies?: string[];
+    imports?: string[];
 };

--- a/src/validation/validateDependencyRules.ts
+++ b/src/validation/validateDependencyRules.ts
@@ -9,11 +9,6 @@ export default function validateDependencyRules(
     sourceFile: NormalizedPath,
     importRecord: ImportRecord
 ) {
-    // If the import is not an external dependency then these rules do not apply
-    if (!importRecord.isExternal) {
-        return;
-    }
-
     // Validate against each config that applies to the imported file
     let configsForSource = getConfigsForFile(sourceFile);
     for (let config of configsForSource) {

--- a/src/validation/validateDependencyRules.ts
+++ b/src/validation/validateDependencyRules.ts
@@ -27,15 +27,15 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord
         return;
     }
 
-    // In order for the the import to be valid, there needs to be some rule that allows it
-    let importAllowed = false;
+    // In order for the the dependency to be valid, there needs to be some rule that allows it
+    let dependencyAllowed = false;
     for (let dependencyPattern of config.dependencies) {
         if (minimatch(importRecord.rawImport, dependencyPattern)) {
-            importAllowed = true;
+            dependencyAllowed = true;
         }
     }
 
-    if (!importAllowed) {
+    if (!dependencyAllowed) {
         reportError(`${sourceFile} is not allowed to import '${importRecord.rawImport}'`);
     }
 }

--- a/src/validation/validateFile.ts
+++ b/src/validation/validateFile.ts
@@ -3,11 +3,19 @@ import TypeScriptProgram from '../core/TypeScriptProgram';
 import validateExportRules from './validateExportRules';
 import getImportsFromFile from '../utils/getImportsFromFile';
 import validateDependencyRules from './validateDependencyRules';
+import validateImportRules from './validateImportRules';
 
 export default function validateFile(filePath: NormalizedPath, tsProgram: TypeScriptProgram) {
     const imports = getImportsFromFile(filePath, tsProgram);
     for (let importRecord of imports) {
         validateExportRules(filePath, importRecord.filePath);
-        validateDependencyRules(filePath, importRecord);
+
+        if (importRecord.isExternal) {
+            // External dependency, so apply dependency rules
+            validateDependencyRules(filePath, importRecord);
+        } else {
+            // Internal dependency, so apply import rules
+            validateImportRules(filePath, importRecord);
+        }
     }
 }

--- a/src/validation/validateImportRules.ts
+++ b/src/validation/validateImportRules.ts
@@ -1,0 +1,43 @@
+import * as path from 'path';
+import Config from '../types/Config';
+import NormalizedPath from '../types/NormalizedPath';
+import getConfigsForFile from '../utils/getConfigsForFile';
+import reportError from '../core/reportError';
+import ImportRecord from '../core/ImportRecord';
+import getTagsForFile from '../utils/getTagsForFile';
+
+export default function validateImportRules(
+    sourceFile: NormalizedPath,
+    importRecord: ImportRecord
+) {
+    // Validate against each config that applies to the imported file
+    let configsForSource = getConfigsForFile(sourceFile);
+    for (let config of configsForSource) {
+        validateConfig(config, sourceFile, importRecord);
+    }
+}
+
+function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord: ImportRecord) {
+    // If the config doesn't specify imports then all imports are allowed
+    if (!config.imports) {
+        return;
+    }
+
+    // If the source file is under the config (i.e. the source and import files share the
+    // config) then we don't apply the import rules
+    if (!path.relative(config.path, importRecord.filePath).startsWith('..')) {
+        return;
+    }
+
+    // For the the import to be valid, one of its tags needs to match one of the allowed tags
+    let importTags = getTagsForFile(importRecord.filePath);
+    for (let tag of config.imports) {
+        if (importTags.indexOf(tag) != -1) {
+            // A tag matched, so the import is valid
+            return;
+        }
+    }
+
+    // If we made it here, the import is invalid
+    reportError(`${sourceFile} is not allowed to import '${importRecord.rawImport}'`);
+}


### PR DESCRIPTION
With this change, you can add an `imports` configuration to `fence.json`.  If this config value is present, only imports that have one of the specified tags will be allowed.

```json
{
    "imports": [
        "tagA",
        "tagB"
    ]
}
```

Note: this only applies to code in the same project; to restrict external dependencies you can use the `dependencies` configuration.