### PR TITLE
Implement accessibleTo option for dependency rules

### DIFF
--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -1,9 +1,10 @@
 import NormalizedPath from './NormalizedPath';
+import DependencyRule from './DependencyRule';
 
 export default interface Config {
     path: NormalizedPath;
     tags?: string[];
     exports?: { [files: string]: string | string[] };
-    dependencies?: string[];
+    dependencies?: DependencyRule[];
     imports?: string[];
 };

--- a/src/types/DependencyRule.ts
+++ b/src/types/DependencyRule.ts
@@ -1,0 +1,4 @@
+import FullDependencyRule from './FullDependencyRule';
+
+type DependencyRule = FullDependencyRule | string;
+export default DependencyRule;

--- a/src/types/FullDependencyRule.ts
+++ b/src/types/FullDependencyRule.ts
@@ -1,0 +1,4 @@
+export default interface FullDependencyRule {
+    dependency: string;
+    accessibleTo: string | string[];
+};

--- a/src/validation/validateDependencyRules.ts
+++ b/src/validation/validateDependencyRules.ts
@@ -3,6 +3,9 @@ import NormalizedPath from '../types/NormalizedPath';
 import getConfigsForFile from '../utils/getConfigsForFile';
 import reportError from '../core/reportError';
 import ImportRecord from '../core/ImportRecord';
+import DependencyRule from '../types/DependencyRule';
+import FullDependencyRule from '../types/FullDependencyRule';
+import fileMatchesTag from '../utils/fileMatchesTag';
 const minimatch = require('minimatch');
 
 export default function validateDependencyRules(
@@ -23,13 +26,33 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord
     }
 
     // In order for the the dependency to be valid, there needs to be some rule that allows it
-    for (let dependencyPattern of config.dependencies) {
-        if (minimatch(importRecord.rawImport, dependencyPattern)) {
+    for (let dependency of config.dependencies) {
+        let dependencyRule = getFullDependencyRule(dependency);
+
+        // Check whether:
+        //   1) The import matches the rule
+        //   2) If necessary, the source file has a relevant tag
+        if (
+            minimatch(importRecord.rawImport, dependencyRule.dependency) &&
+            (!dependencyRule.accessibleTo ||
+                fileMatchesTag(sourceFile, dependencyRule.accessibleTo))
+        ) {
             // A rule matched, so the dependency is valid
             return;
         }
     }
 
-    // If we made it here, the dependency is invalid
+    // If we made it here, we didn't find a rule that allows the dependency
     reportError(`${sourceFile} is not allowed to import '${importRecord.rawImport}'`);
+}
+
+function getFullDependencyRule(dependency: DependencyRule): FullDependencyRule {
+    if (typeof dependency == 'string') {
+        return {
+            dependency,
+            accessibleTo: null,
+        };
+    } else {
+        return dependency;
+    }
 }

--- a/src/validation/validateDependencyRules.ts
+++ b/src/validation/validateDependencyRules.ts
@@ -23,14 +23,13 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord
     }
 
     // In order for the the dependency to be valid, there needs to be some rule that allows it
-    let dependencyAllowed = false;
     for (let dependencyPattern of config.dependencies) {
         if (minimatch(importRecord.rawImport, dependencyPattern)) {
-            dependencyAllowed = true;
+            // A rule matched, so the dependency is valid
+            return;
         }
     }
 
-    if (!dependencyAllowed) {
-        reportError(`${sourceFile} is not allowed to import '${importRecord.rawImport}'`);
-    }
+    // If we made it here, the dependency is invalid
+    reportError(`${sourceFile} is not allowed to import '${importRecord.rawImport}'`);
 }


### PR DESCRIPTION
With this, it is possible to restrict dependencies to modules with given tag.  In the below example, `foo` is accessible to anything, `bar` is accessible to any modules with `tagA`, and `baz/**` is accessible to anything with `tagB` **or** `tagC`.

```json
{
    "dependencies": [
        "foo",
        {
            "dependency": "bar",
            "accessibleTo": "tagA",
        },
        {
            "dependency": "baz/**",
            "accessibleTo": ["tagB", "tagC"],
        }
    ]
}
```