### PR TITLE
Report errors as objects instead of just string messages

### DIFF
--- a/sample/src/componentA/fence.json
+++ b/sample/src/componentA/fence.json
@@ -2,5 +2,6 @@
     "tags": [ "tagA" ],
     "exports": {
         "componentA": "*"
-    }
+    },
+    "imports":[]
 }

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -17,8 +17,8 @@ let hadError = false;
 // Run good-fences
 run({
     ...options,
-    onError(message) {
-        console.error(`Error: ${message}`);
+    onError(error) {
+        console.error(error.detailedMessage);
         hadError = true;
     },
 });

--- a/src/core/reportError.ts
+++ b/src/core/reportError.ts
@@ -1,7 +1,27 @@
+import * as path from 'path';
 import getOptions from '../utils/getOptions';
+import Config from '../types/Config';
 
-export default function reportError(message: string) {
+export default function reportError(
+    message: string,
+    sourceFile: string,
+    rawImport: string,
+    config: Config
+) {
+    let fencePath = config.path + path.sep + 'fence.json';
+
+    let detailedMessage =
+        `Good-fences violation in ${sourceFile}:\n` +
+        `    ${message}: ${rawImport}\n` +
+        `    Fence: ${fencePath}`;
+
     if (getOptions().onError) {
-        getOptions().onError(message);
+        getOptions().onError({
+            message,
+            sourceFile,
+            rawImport,
+            fencePath,
+            detailedMessage,
+        });
     }
 }

--- a/src/types/NormalizedOptions.ts
+++ b/src/types/NormalizedOptions.ts
@@ -1,7 +1,8 @@
 import NormalizedPath from './NormalizedPath';
+import ValidationError from './ValidationError';
 
 export default interface NormalizedOptions {
     project: NormalizedPath;
     rootDir: NormalizedPath;
-    onError?: (message: string) => void;
+    onError?: (error: ValidationError) => void;
 };

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -1,5 +1,7 @@
+import ValidationError from './ValidationError';
+
 export default interface Options {
     project?: string;
     rootDir?: string;
-    onError?: (message: string) => void;
+    onError?: (error: ValidationError) => void;
 };

--- a/src/types/ValidationError.ts
+++ b/src/types/ValidationError.ts
@@ -1,0 +1,7 @@
+export default interface ValidationError {
+    message: string;
+    sourceFile: string;
+    rawImport: string;
+    fencePath: string;
+    detailedMessage: string;
+};

--- a/src/validation/validateDependencyRules.ts
+++ b/src/validation/validateDependencyRules.ts
@@ -43,7 +43,7 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord
     }
 
     // If we made it here, we didn't find a rule that allows the dependency
-    reportError(`${sourceFile} is not allowed to import '${importRecord.rawImport}'`);
+    reportError('Dependency is not allowed', sourceFile, importRecord.rawImport, config);
 }
 
 function getFullDependencyRule(dependency: DependencyRule): FullDependencyRule {

--- a/src/validation/validateExportRules.ts
+++ b/src/validation/validateExportRules.ts
@@ -33,7 +33,7 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importFile: 
     }
 
     // If we made it here, the import is invalid
-    reportError(`${sourceFile} is importing inaccessible module ${importFile}`);
+    reportError('Module is not exported', sourceFile, importFile, config);
 }
 
 function hasMatchingExport(config: Config, sourceFile: NormalizedPath, importFile: NormalizedPath) {

--- a/src/validation/validateImportRules.ts
+++ b/src/validation/validateImportRules.ts
@@ -39,5 +39,5 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord
     }
 
     // If we made it here, the import is invalid
-    reportError(`${sourceFile} is not allowed to import '${importRecord.rawImport}'`);
+    reportError('Import not allowed', sourceFile, importRecord.rawImport, config);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
         "sourceMap": false,
         "outDir": "lib",
         "noImplicitAny": true,
-        "noUnusedLocals": true
+        "noUnusedLocals": true,
+        "noImplicitThis": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
This is a breaking change, but should make error reporting more flexible in the future.  Now, instead of just reporting an error message string, we pass an object with various properties that may be useful to the consumer.  I've also revamped the error message to be a lot more detailed so that it's hopefully easier to track down errors when they happen.