### PR TITLE
Return errors and warnings from the runner (and deprecate the onError option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,6 @@ The `dependencies` property is an array of dependencies to allow.  Each element 
 
 ## Options
 
-### OnError
-
-Provide a callback for reporting errors.
-This option is only available when running good-fences via the API.
-
-Default       | CLI | API
---------------|-----|----
-`console.log` | n/a | `onError: (message: string) => void`
-
 ### Project
 
 Specify the tsconfig file to use for your project.
@@ -158,3 +149,28 @@ Specify the project root directory.
 Default         | CLI                                    | API
 ----------------|----------------------------------------|----
 `process.cwd()` | `--rootDir <string>`<br/>`-r <string>` | `rootDir: string`
+
+## Return value
+
+When running good-fences via the API, the results are returned in a structure like the following:
+
+```json
+{
+    "errors": [
+        {
+            "message": "The error message",
+            "sourceFile": "The source file where the error was encountered",
+            "rawImport": "The offending import",
+            "fencePath": "The fence whose rule was violated",
+            "detailedMessage": "A human-friendly message that includes all of the above"
+        }
+    ],
+    "warnings": [
+        {
+            "message": "The warning message",
+            "fencePath": "The fence which generated the warning",
+            "detailedMessage": "A human-friendly message that includes all of the above"
+        }
+    ]
+}
+```

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -13,12 +13,12 @@ const options = commander
     .parse(process.argv) as RawOptions;
 
 // Run good-fences
-const results = run(options);
+const result = run(options);
 
 // Write errors to the console
-for (const error of results) {
+for (const error of result.errors) {
     console.error(error.detailedMessage);
 }
 
 // Indicate success or failure via the exit code
-process.exitCode = results.length > 0 ? 1 : 0;
+process.exitCode = result.errors.length > 0 ? 1 : 0;

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -12,16 +12,13 @@ const options = commander
     .option('-r, --rootDir <string>', 'root directory of the project')
     .parse(process.argv) as RawOptions;
 
-let hadError = false;
-
 // Run good-fences
-run({
-    ...options,
-    onError(error) {
-        console.error(error.detailedMessage);
-        hadError = true;
-    },
-});
+const results = run(options);
+
+// Write errors to the console
+for (const error of results) {
+    console.error(error.detailedMessage);
+}
 
 // Indicate success or failure via the exit code
-process.exitCode = hadError ? 1 : 0;
+process.exitCode = results.length > 0 ? 1 : 0;

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -15,9 +15,13 @@ const options = commander
 // Run good-fences
 const result = run(options);
 
-// Write errors to the console
+// Write results to the console
 for (const error of result.errors) {
     console.error(error.detailedMessage);
+}
+
+for (const warning of result.warnings) {
+    console.error(warning.detailedMessage);
 }
 
 // Indicate success or failure via the exit code

--- a/src/core/reportError.ts
+++ b/src/core/reportError.ts
@@ -1,6 +1,9 @@
 import * as path from 'path';
 import getOptions from '../utils/getOptions';
 import Config from '../types/config/Config';
+import ValidationError from '../types/ValidationError';
+
+const errors: ValidationError[] = [];
 
 export default function reportError(
     message: string,
@@ -15,13 +18,21 @@ export default function reportError(
         `    ${message}: ${rawImport}\n` +
         `    Fence: ${fencePath}`;
 
+    const validationError: ValidationError = {
+        message,
+        sourceFile,
+        rawImport,
+        fencePath,
+        detailedMessage,
+    };
+
     if (getOptions().onError) {
-        getOptions().onError({
-            message,
-            sourceFile,
-            rawImport,
-            fencePath,
-            detailedMessage,
-        });
+        getOptions().onError(validationError);
     }
+
+    errors.push(validationError);
+}
+
+export function getErrors() {
+    return errors;
 }

--- a/src/core/result.ts
+++ b/src/core/result.ts
@@ -2,10 +2,14 @@ import * as path from 'path';
 import getOptions from '../utils/getOptions';
 import Config from '../types/config/Config';
 import ValidationError from '../types/ValidationError';
+import GoodFencesResult from '../types/GoodFencesResult';
 
-const errors: ValidationError[] = [];
+const result: GoodFencesResult = {
+    errors: [],
+    warnings: [],
+};
 
-export default function reportError(
+export function reportError(
     message: string,
     sourceFile: string,
     rawImport: string,
@@ -30,9 +34,9 @@ export default function reportError(
         getOptions().onError(validationError);
     }
 
-    errors.push(validationError);
+    result.errors.push(validationError);
 }
 
-export function getErrors() {
-    return errors;
+export function getResult() {
+    return result;
 }

--- a/src/core/result.ts
+++ b/src/core/result.ts
@@ -3,7 +3,7 @@ import getOptions from '../utils/getOptions';
 import Config from '../types/config/Config';
 import GoodFencesError from '../types/GoodFencesError';
 import GoodFencesResult from '../types/GoodFencesResult';
-import ConfigWarning from '../types/ConfigWarning';
+import GoodFencesWarning from '../types/GoodFencesWarning';
 
 const result: GoodFencesResult = {
     errors: [],
@@ -46,11 +46,11 @@ export function reportWarning(message: string, config: Config) {
     let fencePath = config.path + path.sep + 'fence.json';
     let detailedMessage = `Good-fences warning: ${message}\n` + `    Fence: ${fencePath}`;
 
-    const configWarning: ConfigWarning = {
+    const warning: GoodFencesWarning = {
         message,
         fencePath,
         detailedMessage,
     };
 
-    result.warnings.push(configWarning);
+    result.warnings.push(warning);
 }

--- a/src/core/result.ts
+++ b/src/core/result.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import getOptions from '../utils/getOptions';
 import Config from '../types/config/Config';
-import ValidationError from '../types/ValidationError';
+import GoodFencesError from '../types/GoodFencesError';
 import GoodFencesResult from '../types/GoodFencesResult';
 import ConfigWarning from '../types/ConfigWarning';
 
@@ -27,7 +27,7 @@ export function reportError(
         `    ${message}: ${rawImport}\n` +
         `    Fence: ${fencePath}`;
 
-    const validationError: ValidationError = {
+    const error: GoodFencesError = {
         message,
         sourceFile,
         rawImport,
@@ -36,10 +36,10 @@ export function reportError(
     };
 
     if (getOptions().onError) {
-        getOptions().onError(validationError);
+        getOptions().onError(error);
     }
 
-    result.errors.push(validationError);
+    result.errors.push(error);
 }
 
 export function reportWarning(message: string, config: Config) {

--- a/src/core/result.ts
+++ b/src/core/result.ts
@@ -3,11 +3,16 @@ import getOptions from '../utils/getOptions';
 import Config from '../types/config/Config';
 import ValidationError from '../types/ValidationError';
 import GoodFencesResult from '../types/GoodFencesResult';
+import ConfigWarning from '../types/ConfigWarning';
 
 const result: GoodFencesResult = {
     errors: [],
     warnings: [],
 };
+
+export function getResult() {
+    return result;
+}
 
 export function reportError(
     message: string,
@@ -37,6 +42,15 @@ export function reportError(
     result.errors.push(validationError);
 }
 
-export function getResult() {
-    return result;
+export function reportWarning(message: string, config: Config) {
+    let fencePath = config.path + path.sep + 'fence.json';
+    let detailedMessage = `Good-fences warning: ${message}\n` + `    Fence: ${fencePath}`;
+
+    const configWarning: ConfigWarning = {
+        message,
+        fencePath,
+        detailedMessage,
+    };
+
+    result.warnings.push(configWarning);
 }

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -3,7 +3,7 @@ import getOptions, { setOptions } from '../utils/getOptions';
 import validateFile from '../validation/validateFile';
 import TypeScriptProgram from './TypeScriptProgram';
 import normalizePath from '../utils/normalizePath';
-import { getErrors } from './reportError';
+import { getResult } from './result';
 
 export function run(rawOptions: RawOptions) {
     // Store options so they can be globally available
@@ -21,5 +21,5 @@ export function run(rawOptions: RawOptions) {
         validateFile(normalizePath(file), tsProgram);
     });
 
-    return getErrors();
+    return getResult();
 }

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -8,6 +8,11 @@ export function run(rawOptions: RawOptions) {
     // Store options so they can be globally available
     setOptions(rawOptions);
 
+    // Warn when using a deprecated option
+    if (getOptions().onError) {
+        console.warn('The onError option is deprecated.  Use the return value from run() instead.');
+    }
+
     // Run validation
     let tsProgram = new TypeScriptProgram(getOptions().project);
     let files = tsProgram.getSourceFiles();

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -3,6 +3,7 @@ import getOptions, { setOptions } from '../utils/getOptions';
 import validateFile from '../validation/validateFile';
 import TypeScriptProgram from './TypeScriptProgram';
 import normalizePath from '../utils/normalizePath';
+import { getErrors } from './reportError';
 
 export function run(rawOptions: RawOptions) {
     // Store options so they can be globally available
@@ -19,4 +20,6 @@ export function run(rawOptions: RawOptions) {
     files.forEach(file => {
         validateFile(normalizePath(file), tsProgram);
     });
+
+    return getErrors();
 }

--- a/src/types/ConfigWarning.ts
+++ b/src/types/ConfigWarning.ts
@@ -1,0 +1,5 @@
+export default interface ConfigWarning {
+    message: string;
+    fencePath: string;
+    detailedMessage: string;
+};

--- a/src/types/GoodFencesError.ts
+++ b/src/types/GoodFencesError.ts
@@ -1,4 +1,4 @@
-export default interface ValidationError {
+export default interface GoodFencesError {
     message: string;
     sourceFile: string;
     rawImport: string;

--- a/src/types/GoodFencesResult.ts
+++ b/src/types/GoodFencesResult.ts
@@ -1,0 +1,6 @@
+import ValidationError from './ValidationError';
+
+export default interface GoodFencesResult {
+    errors: ValidationError[];
+    warnings: ValidationError[];
+};

--- a/src/types/GoodFencesResult.ts
+++ b/src/types/GoodFencesResult.ts
@@ -1,7 +1,7 @@
-import ValidationError from './ValidationError';
+import GoodFencesError from './GoodFencesError';
 import ConfigWarning from './ConfigWarning';
 
 export default interface GoodFencesResult {
-    errors: ValidationError[];
+    errors: GoodFencesError[];
     warnings: ConfigWarning[];
 };

--- a/src/types/GoodFencesResult.ts
+++ b/src/types/GoodFencesResult.ts
@@ -1,7 +1,7 @@
 import GoodFencesError from './GoodFencesError';
-import ConfigWarning from './ConfigWarning';
+import GoodFencesWarning from './GoodFencesWarning';
 
 export default interface GoodFencesResult {
     errors: GoodFencesError[];
-    warnings: ConfigWarning[];
+    warnings: GoodFencesWarning[];
 };

--- a/src/types/GoodFencesResult.ts
+++ b/src/types/GoodFencesResult.ts
@@ -1,6 +1,7 @@
 import ValidationError from './ValidationError';
+import ConfigWarning from './ConfigWarning';
 
 export default interface GoodFencesResult {
     errors: ValidationError[];
-    warnings: ValidationError[];
+    warnings: ConfigWarning[];
 };

--- a/src/types/GoodFencesWarning.ts
+++ b/src/types/GoodFencesWarning.ts
@@ -1,4 +1,4 @@
-export default interface ConfigWarning {
+export default interface GoodFencesWarning {
     message: string;
     fencePath: string;
     detailedMessage: string;

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -1,9 +1,9 @@
 import NormalizedPath from './NormalizedPath';
-import ValidationError from './ValidationError';
+import GoodFencesError from './GoodFencesError';
 
 export default interface Options {
     project: NormalizedPath;
     rootDir: NormalizedPath;
     ignoreExternalFences: boolean;
-    onError?: (error: ValidationError) => void;
+    onError?: (error: GoodFencesError) => void;
 };

--- a/src/types/RawOptions.ts
+++ b/src/types/RawOptions.ts
@@ -1,8 +1,8 @@
-import ValidationError from './ValidationError';
+import GoodFencesError from './GoodFencesError';
 
 export default interface RawOptions {
     project?: string;
     rootDir?: string;
     ignoreExternalFences?: boolean;
-    onError?: (error: ValidationError) => void;
+    onError?: (error: GoodFencesError) => void;
 };

--- a/src/validation/validateDependencyRules.ts
+++ b/src/validation/validateDependencyRules.ts
@@ -1,7 +1,7 @@
 import Config from '../types/config/Config';
 import NormalizedPath from '../types/NormalizedPath';
 import getConfigsForFile from '../utils/getConfigsForFile';
-import reportError from '../core/reportError';
+import { reportError } from '../core/result';
 import ImportRecord from '../core/ImportRecord';
 import fileMatchesTag from '../utils/fileMatchesTag';
 const minimatch = require('minimatch');

--- a/src/validation/validateExportRules.ts
+++ b/src/validation/validateExportRules.ts
@@ -4,7 +4,7 @@ import NormalizedPath from '../types/NormalizedPath';
 import getConfigsForFile from '../utils/getConfigsForFile';
 import fileMatchesConfigGlob from '../utils/fileMatchesConfigGlob';
 import fileMatchesTag from '../utils/fileMatchesTag';
-import reportError from '../core/reportError';
+import { reportError } from '../core/result';
 
 export default function validateExportRules(
     sourceFile: NormalizedPath,

--- a/src/validation/validateImportRules.ts
+++ b/src/validation/validateImportRules.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import Config from '../types/config/Config';
 import NormalizedPath from '../types/NormalizedPath';
 import getConfigsForFile from '../utils/getConfigsForFile';
-import reportError from '../core/reportError';
+import { reportError } from '../core/result';
 import ImportRecord from '../core/ImportRecord';
 import getTagsForFile from '../utils/getTagsForFile';
 


### PR DESCRIPTION
This changes the good-fences API to return a results structure from the runner which contains the errors and warnings.  With this change the `onError` option is deprecated.