### PR TITLE
Report raw import in a consistent way

### DIFF
--- a/src/core/result.ts
+++ b/src/core/result.ts
@@ -4,6 +4,7 @@ import Config from '../types/config/Config';
 import GoodFencesError from '../types/GoodFencesError';
 import GoodFencesResult from '../types/GoodFencesResult';
 import GoodFencesWarning from '../types/GoodFencesWarning';
+import ImportRecord from './ImportRecord';
 
 const result: GoodFencesResult = {
     errors: [],
@@ -17,20 +18,20 @@ export function getResult() {
 export function reportError(
     message: string,
     sourceFile: string,
-    rawImport: string,
+    importRecord: ImportRecord,
     config: Config
 ) {
     let fencePath = config.path + path.sep + 'fence.json';
 
     let detailedMessage =
         `Good-fences violation in ${sourceFile}:\n` +
-        `    ${message}: ${rawImport}\n` +
+        `    ${message}: ${importRecord.rawImport}\n` +
         `    Fence: ${fencePath}`;
 
     const error: GoodFencesError = {
         message,
         sourceFile,
-        rawImport,
+        rawImport: importRecord.rawImport,
         fencePath,
         detailedMessage,
     };

--- a/src/validation/validateDependencyRules.ts
+++ b/src/validation/validateDependencyRules.ts
@@ -39,5 +39,5 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord
     }
 
     // If we made it here, we didn't find a rule that allows the dependency
-    reportError('Dependency is not allowed', sourceFile, importRecord.rawImport, config);
+    reportError('Dependency is not allowed', sourceFile, importRecord, config);
 }

--- a/src/validation/validateExportRules.ts
+++ b/src/validation/validateExportRules.ts
@@ -5,17 +5,18 @@ import getConfigsForFile from '../utils/getConfigsForFile';
 import fileMatchesConfigGlob from '../utils/fileMatchesConfigGlob';
 import fileMatchesTag from '../utils/fileMatchesTag';
 import { reportError } from '../core/result';
+import ImportRecord from '../core/ImportRecord';
 
 export default function validateExportRules(
     sourceFile: NormalizedPath,
-    importFile: NormalizedPath
+    importRecord: ImportRecord
 ) {
     // Validate against each config that applies to the imported file
-    let configsForImport = getConfigsForFile(importFile);
-    configsForImport.forEach(config => validateConfig(config, sourceFile, importFile));
+    let configsForImport = getConfigsForFile(importRecord.filePath);
+    configsForImport.forEach(config => validateConfig(config, sourceFile, importRecord));
 }
 
-function validateConfig(config: Config, sourceFile: NormalizedPath, importFile: NormalizedPath) {
+function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord: ImportRecord) {
     // If the source file is under the config (i.e. the source and import files share the
     // config) then we don't apply the export rules
     if (!path.relative(config.path, sourceFile).startsWith('..')) {
@@ -28,12 +29,12 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importFile: 
     }
 
     // See if the config has an export rule that matches
-    if (hasMatchingExport(config, sourceFile, importFile)) {
+    if (hasMatchingExport(config, sourceFile, importRecord.filePath)) {
         return;
     }
 
     // If we made it here, the import is invalid
-    reportError('Module is not exported', sourceFile, importFile, config);
+    reportError('Module is not exported', sourceFile, importRecord, config);
 }
 
 function hasMatchingExport(config: Config, sourceFile: NormalizedPath, importFile: NormalizedPath) {

--- a/src/validation/validateFile.ts
+++ b/src/validation/validateFile.ts
@@ -8,7 +8,7 @@ import validateImportRules from './validateImportRules';
 export default function validateFile(filePath: NormalizedPath, tsProgram: TypeScriptProgram) {
     const imports = getImportsFromFile(filePath, tsProgram);
     for (let importRecord of imports) {
-        validateExportRules(filePath, importRecord.filePath);
+        validateExportRules(filePath, importRecord);
 
         if (importRecord.isExternal) {
             // External dependency, so apply dependency rules

--- a/src/validation/validateImportRules.ts
+++ b/src/validation/validateImportRules.ts
@@ -39,5 +39,5 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord
     }
 
     // If we made it here, the import is invalid
-    reportError('Import not allowed', sourceFile, importRecord.rawImport, config);
+    reportError('Import not allowed', sourceFile, importRecord, config);
 }


### PR DESCRIPTION
In some cases we were reporting the raw import as a relative path and in others as an absolute path.  With this change we report it in a consistent way: as a relative path (i.e. the way it shows up in the source file).