### PR TITLE
Add an end-to-end test

### DIFF
--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -3,7 +3,7 @@ import RawOptions from '../types/RawOptions';
 import { run } from './runner';
 
 // Read the package version from package.json
-const packageVersion = require('../../package').version;
+const packageVersion = require('../../package.json').version;
 
 // Parse command line options
 const options = commander

--- a/test/core/cliTests.ts
+++ b/test/core/cliTests.ts
@@ -1,0 +1,36 @@
+describe('cli', () => {
+    it('returns the expected results', () => {
+        // Arrange
+        const errors: string[] = [];
+        process.argv = ['node', './lib/core/cli.js', '--rootDir', './sample'];
+
+        spyOn(console, 'error').and.callFake(error => {
+            errors.push(error);
+        });
+
+        // Act
+        require('../../src/core/cli');
+
+        // Assert
+        expect(errors).toEqual(expectedErrors);
+    });
+});
+
+// TODO: get errors from file?
+// TODO: deal with absolute paths
+// TODO: rename endToEndTests
+// Maybe just go to runner?
+const expectedErrors = [
+    `Good-fences violation in C:\\repos\\good-fences\\sample\\src\\componentA\\helperA1.ts:\n
+    Module is not exported: C:\\repos\\good-fences\\sample\\src\\componentB\\helperB1.ts\n
+    Fence: C:\\repos\\good-fences\\sample\\src\\componentB\\fence.json`,
+    `Good-fences violation in C:\\repos\\good-fences\\sample\\src\\componentA\\helperA1.ts:\n
+    Import not allowed: ../componentB/helperB1\n
+    Fence: C:\\repos\\good-fences\\sample\\src\\componentA\\fence.json`,
+    `Good-fences violation in C:\\repos\\good-fences\\sample\\src\\componentA\\componentA.ts:\n
+    Import not allowed: ../componentB/componentB\n
+    Fence: C:\\repos\\good-fences\\sample\\src\\componentA\\fence.json`,
+    `Good-fences violation in C:\\repos\\good-fences\\sample\\src\\index.ts:\n
+    Module is not exported: C:\\repos\\good-fences\\sample\\src\\componentB\\componentB.ts\n
+    Fence: C:\\repos\\good-fences\\sample\\src\\componentB\\fence.json`,
+];

--- a/test/endToEnd/endToEndTests.expected.json
+++ b/test/endToEnd/endToEndTests.expected.json
@@ -2,8 +2,26 @@
     "errors": [
         {
             "message": "Module is not exported",
-            "sourceFile": "sample\\src\\componentB\\helperA1.ts",
+            "sourceFile": "sample\\src\\componentA\\helperA1.ts",
             "rawImport": "sample\\src\\componentB\\helperB1.ts",
+            "fencePath": "sample\\src\\componentB\\fence.json"
+        },
+        {
+            "message": "Import not allowed",
+            "sourceFile": "sample\\src\\componentA\\helperA1.ts",
+            "rawImport": "sample\\src\\componentB\\helperB1.ts",
+            "fencePath": "sample\\src\\componentA\\fence.json"
+        },
+        {
+            "message": "Import not allowed",
+            "sourceFile": "sample\\src\\componentA\\componentA.ts",
+            "rawImport": "sample\\src\\componentB\\componentB.ts",
+            "fencePath": "sample\\src\\componentA\\fence.json"
+        },
+        {
+            "message": "Module is not exported",
+            "sourceFile": "sample\\src\\index.ts",
+            "rawImport": "sample\\src\\componentB\\componentB.ts",
             "fencePath": "sample\\src\\componentB\\fence.json"
         }
     ],

--- a/test/endToEnd/endToEndTests.expected.json
+++ b/test/endToEnd/endToEndTests.expected.json
@@ -2,27 +2,27 @@
     "errors": [
         {
             "message": "Module is not exported",
-            "sourceFile": "sample\\src\\componentA\\helperA1.ts",
-            "rawImport": "sample\\src\\componentB\\helperB1.ts",
-            "fencePath": "sample\\src\\componentB\\fence.json"
+            "sourceFile": "sample/src/componentA/helperA1.ts",
+            "rawImport": "../componentB/helperB1",
+            "fencePath": "sample/src/componentB/fence.json"
         },
         {
             "message": "Import not allowed",
-            "sourceFile": "sample\\src\\componentA\\helperA1.ts",
-            "rawImport": "sample\\src\\componentB\\helperB1.ts",
-            "fencePath": "sample\\src\\componentA\\fence.json"
+            "sourceFile": "sample/src/componentA/helperA1.ts",
+            "rawImport": "../componentB/helperB1",
+            "fencePath": "sample/src/componentA/fence.json"
         },
         {
             "message": "Import not allowed",
-            "sourceFile": "sample\\src\\componentA\\componentA.ts",
-            "rawImport": "sample\\src\\componentB\\componentB.ts",
-            "fencePath": "sample\\src\\componentA\\fence.json"
+            "sourceFile": "sample/src/componentA/componentA.ts",
+            "rawImport": "../componentB/componentB",
+            "fencePath": "sample/src/componentA/fence.json"
         },
         {
             "message": "Module is not exported",
-            "sourceFile": "sample\\src\\index.ts",
-            "rawImport": "sample\\src\\componentB\\componentB.ts",
-            "fencePath": "sample\\src\\componentB\\fence.json"
+            "sourceFile": "sample/src/index.ts",
+            "rawImport": "./componentB/componentB",
+            "fencePath": "sample/src/componentB/fence.json"
         }
     ],
     "warnings": []

--- a/test/endToEnd/endToEndTests.expected.json
+++ b/test/endToEnd/endToEndTests.expected.json
@@ -1,0 +1,11 @@
+{
+    "errors": [
+        {
+            "message": "Module is not exported",
+            "sourceFile": "sample\\src\\componentB\\helperA1.ts",
+            "rawImport": "sample\\src\\componentB\\helperB1.ts",
+            "fencePath": "sample\\src\\componentB\\fence.json"
+        }
+    ],
+    "warnings": []
+}

--- a/test/endToEnd/endToEndTests.ts
+++ b/test/endToEnd/endToEndTests.ts
@@ -1,18 +1,18 @@
-describe('cli', () => {
+import { run } from '../../src/core/runner';
+
+describe('runner', () => {
     it('returns the expected results', () => {
         // Arrange
-        const errors: string[] = [];
-        process.argv = ['node', './lib/core/cli.js', '--rootDir', './sample'];
-
-        spyOn(console, 'error').and.callFake(error => {
-            errors.push(error);
-        });
+        const expectedResults = require('./endToEndTests.expected.json');
 
         // Act
-        require('../../src/core/cli');
+        const actualResults = run({
+            rootDir: './sample',
+        });
 
         // Assert
-        expect(errors).toEqual(expectedErrors);
+        // TODO: loop and compare, normalizing paths
+        expect(actualResults).toEqual(expectedResults);
     });
 });
 

--- a/test/endToEnd/endToEndTests.ts
+++ b/test/endToEnd/endToEndTests.ts
@@ -32,7 +32,6 @@ function removeDetailedMessages(results: GoodFencesResult) {
 function normalizePaths(results: GoodFencesResult) {
     for (const error of results.errors) {
         error.fencePath = normalizePath(error.fencePath);
-        error.rawImport = normalizePath(error.rawImport);
         error.sourceFile = normalizePath(error.sourceFile);
     }
 

--- a/test/endToEnd/endToEndTests.ts
+++ b/test/endToEnd/endToEndTests.ts
@@ -1,4 +1,6 @@
 import { run } from '../../src/core/runner';
+import GoodFencesResult from '../../src/types/GoodFencesResult';
+import normalizePath from '../../src/utils/normalizePath';
 
 describe('runner', () => {
     it('returns the expected results', () => {
@@ -11,26 +13,30 @@ describe('runner', () => {
         });
 
         // Assert
-        // TODO: loop and compare, normalizing paths
+        removeDetailedMessages(actualResults);
+        normalizePaths(expectedResults);
         expect(actualResults).toEqual(expectedResults);
     });
 });
 
-// TODO: get errors from file?
-// TODO: deal with absolute paths
-// TODO: rename endToEndTests
-// Maybe just go to runner?
-const expectedErrors = [
-    `Good-fences violation in C:\\repos\\good-fences\\sample\\src\\componentA\\helperA1.ts:\n
-    Module is not exported: C:\\repos\\good-fences\\sample\\src\\componentB\\helperB1.ts\n
-    Fence: C:\\repos\\good-fences\\sample\\src\\componentB\\fence.json`,
-    `Good-fences violation in C:\\repos\\good-fences\\sample\\src\\componentA\\helperA1.ts:\n
-    Import not allowed: ../componentB/helperB1\n
-    Fence: C:\\repos\\good-fences\\sample\\src\\componentA\\fence.json`,
-    `Good-fences violation in C:\\repos\\good-fences\\sample\\src\\componentA\\componentA.ts:\n
-    Import not allowed: ../componentB/componentB\n
-    Fence: C:\\repos\\good-fences\\sample\\src\\componentA\\fence.json`,
-    `Good-fences violation in C:\\repos\\good-fences\\sample\\src\\index.ts:\n
-    Module is not exported: C:\\repos\\good-fences\\sample\\src\\componentB\\componentB.ts\n
-    Fence: C:\\repos\\good-fences\\sample\\src\\componentB\\fence.json`,
-];
+function removeDetailedMessages(results: GoodFencesResult) {
+    for (const error of results.errors) {
+        delete error.detailedMessage;
+    }
+
+    for (const warning of results.warnings) {
+        delete warning.detailedMessage;
+    }
+}
+
+function normalizePaths(results: GoodFencesResult) {
+    for (const error of results.errors) {
+        error.fencePath = normalizePath(error.fencePath);
+        error.rawImport = normalizePath(error.rawImport);
+        error.sourceFile = normalizePath(error.sourceFile);
+    }
+
+    for (const warning of results.warnings) {
+        warning.fencePath = normalizePath(warning.fencePath);
+    }
+}


### PR DESCRIPTION
Add and end-to-end test that runs against the `sample/` directory and validates that all the results are correct.  To get this to work all the paths need to be normalized so they match up across different machines and environments.