### PR TITLE
Export result types from the index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
+export { default as GoodFencesError } from './types/GoodFencesError';
+export { default as GoodFencesResult } from './types/GoodFencesResult';
+export { default as GoodFencesWarning } from './types/GoodFencesWarning';
 export { default as Options } from './types/RawOptions';
 export { run } from './core/runner';


### PR DESCRIPTION
Consumers need to know about the `GoodFencesResult` type (and the related `GoodFencesError` and `GoodFencesWarning` types) so they should be exported from the index.