### PR TITLE
Stop checking for deprecated exports schema

### DIFF
--- a/src/utils/loadConfig.ts
+++ b/src/utils/loadConfig.ts
@@ -6,7 +6,6 @@ import normalizePath from './normalizePath';
 import RawDependencyRule from '../types/rawConfig/RawDependencyRule';
 import RawExportRule from '../types/rawConfig/RawExportRule';
 import ExportRule from '../types/config/ExportRule';
-import { reportWarning } from '../core/result';
 
 export default function loadConfig(file: string): Config {
     // Load the raw config
@@ -20,10 +19,6 @@ export default function loadConfig(file: string): Config {
         dependencies: normalizeDependencyRules(rawConfig.dependencies),
         imports: rawConfig.imports,
     };
-
-    if (rawConfig.exports && !Array.isArray(rawConfig.exports)) {
-        reportWarning('Config is using deprecated style for exports.', config);
-    }
 
     return config;
 }


### PR DESCRIPTION
I forgot to remove this when I removed support for the old-style exports.