### PR TITLE
Recursively walk directories to find fences

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,11 @@
     "author": "Scott Mikula <mikula@gmail.com>",
     "dependencies": {
         "commander": "^2.11.0",
-        "glob": "^7.1.2",
         "minimatch": "^3.0.4",
         "typescript": "^3.5.3"
     },
     "devDependencies": {
         "@types/commander": "^2.11.0",
-        "@types/glob": "^5.0.33",
         "@types/jest": "^21.1.2",
         "@types/node": "^12.7.8",
         "jest": "^24.8.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "@types/commander": "^2.11.0",
         "@types/glob": "^5.0.33",
         "@types/jest": "^21.1.2",
-        "@types/node": "^7.0.4",
+        "@types/node": "^12.7.8",
         "jest": "^24.8.0"
     },
     "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -368,10 +368,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.46.tgz#6e1766b2d0ed06631d5b5f87bb8e72c8dbb6888e"
   integrity sha512-rRkP4kb5JYIfAoRKaDbcdPZBcTNOgzSApyzhPN9e6rhViSJAWQGlSXIX5gc75iR02jikhpzy3usu31wMHllfFw==
 
-"@types/node@^7.0.4":
-  version "7.0.43"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.43.tgz#a187e08495a075f200ca946079c914e1a5fe962c"
-  integrity sha512-7scYwwfHNppXvH/9JzakbVxk0o0QUILVk1Lv64GRaxwPuGpnF1QBiwdvhDpLcymb8BpomQL3KYoWKq3wUdDMhQ==
+"@types/node@^12.7.8":
+  version "12.7.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.8.tgz#cb1bf6800238898bc2ff6ffa5702c3cadd350708"
+  integrity sha512-FMdVn84tJJdV+xe+53sYiZS4R5yn1mAIxfj+DVoNiQjTYz1+OYmjwEZr1ev9nU0axXwda0QDbYl06QHanRVH3A==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,14 +325,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/glob@^5.0.33":
-  version "5.0.33"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-5.0.33.tgz#3dff7c6ce09d65abe919c7961dc3dee016f36ad7"
-  integrity sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==
-  dependencies:
-    "@types/minimatch" "*"
-    "@types/node" "*"
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -357,11 +349,6 @@
   version "21.1.2"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-21.1.2.tgz#05ebfa64817b626694ced56745a7949281981048"
   integrity sha512-mZ0zVDNxpz44GzPHtKCFOUDEdcRUk2c1fDzWCpiGuyeJLLMOLuLlzuqOQk5fufVUJarwm4aZcQHLdYH22h25zg==
-
-"@types/minimatch@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.1.tgz#b683eb60be358304ef146f5775db4c0e3696a550"
-  integrity sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==
 
 "@types/node@*":
   version "8.0.46"


### PR DESCRIPTION
It turns out `glob` is pretty slow in large directory structures.  Since we know exactly what we're looking for (files named `fence.json`) it's faster to just walk the directory tree recursively.  Additionally, this gives us a chance to short-circuit all the `node_modules` directories when `ignoreExternalFences` is on.