### PR TITLE
Mechanism to report errors in config files

### DIFF
--- a/src/core/result.ts
+++ b/src/core/result.ts
@@ -37,6 +37,21 @@ export function reportViolation(
     result.errors.push(error);
 }
 
+export function reportConfigError(message: string, config: Config) {
+    let fencePath = config.path + path.sep + 'fence.json';
+
+    let detailedMessage =
+        `Good-fences configuration error: ${message}\n` + `    Fence: ${fencePath}`;
+
+    const error: GoodFencesError = {
+        message,
+        fencePath,
+        detailedMessage,
+    };
+
+    result.errors.push(error);
+}
+
 export function reportWarning(message: string, config: Config) {
     let fencePath = config.path + path.sep + 'fence.json';
     let detailedMessage = `Good-fences warning: ${message}\n` + `    Fence: ${fencePath}`;

--- a/src/core/result.ts
+++ b/src/core/result.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import Config from '../types/config/Config';
 import GoodFencesError from '../types/GoodFencesError';
 import GoodFencesResult from '../types/GoodFencesResult';
-import GoodFencesWarning from '../types/GoodFencesWarning';
 import ImportRecord from './ImportRecord';
 
 const result: GoodFencesResult = {
@@ -42,7 +41,7 @@ export function reportWarning(message: string, config: Config) {
     let fencePath = config.path + path.sep + 'fence.json';
     let detailedMessage = `Good-fences warning: ${message}\n` + `    Fence: ${fencePath}`;
 
-    const warning: GoodFencesWarning = {
+    const warning: GoodFencesError = {
         message,
         fencePath,
         detailedMessage,

--- a/src/core/result.ts
+++ b/src/core/result.ts
@@ -13,7 +13,7 @@ export function getResult() {
     return result;
 }
 
-export function reportError(
+export function reportViolation(
     message: string,
     sourceFile: string,
     importRecord: ImportRecord,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 export { default as GoodFencesError } from './types/GoodFencesError';
 export { default as GoodFencesResult } from './types/GoodFencesResult';
-export { default as GoodFencesWarning } from './types/GoodFencesWarning';
 export { default as Options } from './types/RawOptions';
 export { run } from './core/runner';

--- a/src/types/GoodFencesError.ts
+++ b/src/types/GoodFencesError.ts
@@ -1,7 +1,7 @@
 export default interface GoodFencesError {
     message: string;
-    sourceFile: string;
-    rawImport: string;
+    sourceFile?: string;
+    rawImport?: string;
     fencePath: string;
     detailedMessage: string;
 };

--- a/src/types/GoodFencesResult.ts
+++ b/src/types/GoodFencesResult.ts
@@ -1,7 +1,6 @@
 import GoodFencesError from './GoodFencesError';
-import GoodFencesWarning from './GoodFencesWarning';
 
 export default interface GoodFencesResult {
     errors: GoodFencesError[];
-    warnings: GoodFencesWarning[];
+    warnings: GoodFencesError[];
 };

--- a/src/types/GoodFencesWarning.ts
+++ b/src/types/GoodFencesWarning.ts
@@ -1,5 +1,0 @@
-export default interface GoodFencesWarning {
-    message: string;
-    fencePath: string;
-    detailedMessage: string;
-};

--- a/src/validation/validateDependencyRules.ts
+++ b/src/validation/validateDependencyRules.ts
@@ -1,7 +1,7 @@
 import Config from '../types/config/Config';
 import NormalizedPath from '../types/NormalizedPath';
 import getConfigsForFile from '../utils/getConfigsForFile';
-import { reportError } from '../core/result';
+import { reportViolation } from '../core/result';
 import ImportRecord from '../core/ImportRecord';
 import fileHasNecessaryTag from '../utils/fileHasNecessaryTag';
 const minimatch = require('minimatch');
@@ -38,5 +38,5 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord
     }
 
     // If we made it here, we didn't find a rule that allows the dependency
-    reportError('Dependency is not allowed', sourceFile, importRecord, config);
+    reportViolation('Dependency is not allowed', sourceFile, importRecord, config);
 }

--- a/src/validation/validateExportRules.ts
+++ b/src/validation/validateExportRules.ts
@@ -4,7 +4,7 @@ import NormalizedPath from '../types/NormalizedPath';
 import getConfigsForFile from '../utils/getConfigsForFile';
 import fileMatchesConfigGlob from '../utils/fileMatchesConfigGlob';
 import fileHasNecessaryTag from '../utils/fileHasNecessaryTag';
-import { reportError } from '../core/result';
+import { reportViolation } from '../core/result';
 import ImportRecord from '../core/ImportRecord';
 
 export default function validateExportRules(
@@ -34,7 +34,7 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord
     }
 
     // If we made it here, the import is invalid
-    reportError('Module is not exported', sourceFile, importRecord, config);
+    reportViolation('Module is not exported', sourceFile, importRecord, config);
 }
 
 function hasMatchingExport(config: Config, sourceFile: NormalizedPath, importFile: NormalizedPath) {

--- a/src/validation/validateImportRules.ts
+++ b/src/validation/validateImportRules.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import Config from '../types/config/Config';
 import NormalizedPath from '../types/NormalizedPath';
 import getConfigsForFile from '../utils/getConfigsForFile';
-import { reportError } from '../core/result';
+import { reportViolation } from '../core/result';
 import ImportRecord from '../core/ImportRecord';
 import getTagsForFile from '../utils/getTagsForFile';
 
@@ -39,5 +39,5 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord
     }
 
     // If we made it here, the import is invalid
-    reportError('Import not allowed', sourceFile, importRecord, config);
+    reportViolation('Import not allowed', sourceFile, importRecord, config);
 }


### PR DESCRIPTION
This implements `reportConfigError` which is used to report errors in `fence.json` configuration files.  I also consolidated `GoodFencesError` and `GoodFencesWarning` since they can mostly be used interchangeably.