### PR TITLE
Do some validation when loading fence.json files

### DIFF
--- a/src/core/result.ts
+++ b/src/core/result.ts
@@ -37,8 +37,8 @@ export function reportViolation(
     result.errors.push(error);
 }
 
-export function reportConfigError(message: string, config: Config) {
-    let fencePath = config.path + path.sep + 'fence.json';
+export function reportConfigError(message: string, configPath: string) {
+    let fencePath = configPath + path.sep + 'fence.json';
 
     let detailedMessage =
         `Good-fences configuration error: ${message}\n` + `    Fence: ${fencePath}`;
@@ -52,8 +52,8 @@ export function reportConfigError(message: string, config: Config) {
     result.errors.push(error);
 }
 
-export function reportWarning(message: string, config: Config) {
-    let fencePath = config.path + path.sep + 'fence.json';
+export function reportWarning(message: string, configPath: string) {
+    let fencePath = configPath + path.sep + 'fence.json';
     let detailedMessage = `Good-fences warning: ${message}\n` + `    Fence: ${fencePath}`;
 
     const warning: GoodFencesError = {

--- a/src/utils/getAllConfigs.ts
+++ b/src/utils/getAllConfigs.ts
@@ -14,8 +14,7 @@ export default function getAllConfigs(): ConfigSet {
         accumulateFences(getOptions().rootDir, files, getOptions().ignoreExternalFences);
 
         files.forEach(file => {
-            let config = loadConfig(file);
-            configSet[config.path] = config;
+            loadConfig(file, configSet);
         });
     }
 

--- a/src/utils/loadConfig.ts
+++ b/src/utils/loadConfig.ts
@@ -5,22 +5,29 @@ import Config from '../types/config/Config';
 import normalizePath from './normalizePath';
 import RawDependencyRule from '../types/rawConfig/RawDependencyRule';
 import RawExportRule from '../types/rawConfig/RawExportRule';
+import ConfigSet from '../types/ConfigSet';
 import ExportRule from '../types/config/ExportRule';
+import validateRawConfig from '../validation/validateRawConfig';
 
-export default function loadConfig(file: string): Config {
+export default function loadConfig(file: string, configSet: ConfigSet) {
     // Load the raw config
     let rawConfig: RawConfig = JSON.parse(fs.readFileSync(file).toString());
 
-    // Normalize it
-    const config: Config = {
-        path: normalizePath(path.dirname(file)),
-        tags: rawConfig.tags,
-        exports: normalizeExportRules(rawConfig.exports),
-        dependencies: normalizeDependencyRules(rawConfig.dependencies),
-        imports: rawConfig.imports,
-    };
+    // Validate it
+    const configPath = normalizePath(path.dirname(file));
+    if (validateRawConfig(rawConfig, configPath)) {
+        // Normalize it
+        const config: Config = {
+            path: configPath,
+            tags: rawConfig.tags,
+            exports: normalizeExportRules(rawConfig.exports),
+            dependencies: normalizeDependencyRules(rawConfig.dependencies),
+            imports: rawConfig.imports,
+        };
 
-    return config;
+        // Add it to the config set
+        configSet[config.path] = config;
+    }
 }
 
 function normalizeDependencyRules(rules: RawDependencyRule[]) {

--- a/src/validation/validateRawConfig.ts
+++ b/src/validation/validateRawConfig.ts
@@ -1,0 +1,41 @@
+import { reportWarning, reportConfigError } from '../core/result';
+import RawConfig from '../types/rawConfig/RawConfig';
+
+// Returns true if the config validates successfully
+export default function validateRawConfig(rawConfig: RawConfig, configPath: string) {
+    let hasError = false;
+
+    if ((rawConfig as any).export && !rawConfig.exports) {
+        reportWarning("Config defines an 'export' property.  Did you mean 'exports'?", configPath);
+    }
+
+    if ((rawConfig as any).import && !rawConfig.imports) {
+        reportWarning("Config defines an 'import' property.  Did you mean 'imports'?", configPath);
+    }
+
+    if (rawConfig.tags && !Array.isArray(rawConfig.tags)) {
+        reportConfigError("The 'tags' property should be an array of tag strings.", configPath);
+        hasError = true;
+    }
+
+    if (rawConfig.exports && !Array.isArray(rawConfig.exports)) {
+        reportConfigError("The 'exports' property should be an array of export rules.", configPath);
+        hasError = true;
+    }
+
+    if (rawConfig.dependencies && !Array.isArray(rawConfig.dependencies)) {
+        reportConfigError(
+            "The 'dependencies' property should be an array of dependency rules.",
+            configPath
+        );
+
+        hasError = true;
+    }
+
+    if (rawConfig.imports && !Array.isArray(rawConfig.imports)) {
+        reportConfigError("The 'imports' property should be an array of import rules.", configPath);
+        hasError = true;
+    }
+
+    return !hasError;
+}

--- a/src/validation/validateTagsExist.ts
+++ b/src/validation/validateTagsExist.ts
@@ -24,7 +24,7 @@ export function validateTagsExist() {
             if (!allTags.has(tag)) {
                 reportWarning(
                     `Tag '${tag}' is referred to but is not defined in any fence.`,
-                    config
+                    config.path
                 );
             }
         });

--- a/test/utils/loadConfigTests.ts
+++ b/test/utils/loadConfigTests.ts
@@ -2,17 +2,31 @@ import * as fs from 'fs';
 import RawConfig from '../../src/types/rawConfig/RawConfig';
 import loadConfig, { normalizeExportRules } from '../../src/utils/loadConfig';
 import * as normalizePath from '../../src/utils/normalizePath';
+import ConfigSet from '../../src/types/ConfigSet';
 
 describe('loadConfig', () => {
     const configPath = 'configPath';
     const normalizedPath = 'normalizedPath';
 
     let rawConfig: RawConfig;
+    let configSet: ConfigSet;
 
     beforeEach(() => {
         spyOn(fs, 'readFileSync').and.returnValue({});
         spyOn(JSON, 'parse').and.callFake(() => rawConfig);
         spyOn(normalizePath, 'default').and.returnValue(normalizedPath);
+        configSet = {};
+    });
+
+    it('adds the config to the configSet object', () => {
+        // Arrange
+        rawConfig = {};
+
+        // Act
+        loadConfig(configPath, configSet);
+
+        // Assert
+        expect(configSet[normalizedPath]).toBeDefined();
     });
 
     it('adds the normalized path to the config object', () => {
@@ -20,10 +34,10 @@ describe('loadConfig', () => {
         rawConfig = {};
 
         // Act
-        let config = loadConfig(configPath);
+        loadConfig(configPath, configSet);
 
         // Assert
-        expect(config.path).toBe(normalizedPath);
+        expect(configSet[normalizedPath].path).toBe(normalizedPath);
     });
 
     it('includes the tags', () => {
@@ -32,10 +46,10 @@ describe('loadConfig', () => {
         rawConfig = { tags };
 
         // Act
-        let config = loadConfig(configPath);
+        loadConfig(configPath, configSet);
 
         // Assert
-        expect(config.tags).toBe(tags);
+        expect(configSet[normalizedPath].tags).toBe(tags);
     });
 
     it('includes the imports', () => {
@@ -44,10 +58,10 @@ describe('loadConfig', () => {
         rawConfig = { imports };
 
         // Act
-        let config = loadConfig(configPath);
+        loadConfig(configPath, configSet);
 
         // Assert
-        expect(config.imports).toBe(imports);
+        expect(configSet[normalizedPath].imports).toBe(imports);
     });
 
     it('normalizes the dependency rules', () => {
@@ -68,10 +82,10 @@ describe('loadConfig', () => {
         rawConfig = { dependencies };
 
         // Act
-        let config = loadConfig(configPath);
+        loadConfig(configPath, configSet);
 
         // Assert
-        expect(config.dependencies).toEqual(normalizedDependencies);
+        expect(configSet[normalizedPath].dependencies).toEqual(normalizedDependencies);
     });
 });
 

--- a/test/validation/validateTagsExistTests.ts
+++ b/test/validation/validateTagsExistTests.ts
@@ -74,6 +74,7 @@ describe('validateTagsExist', () => {
     it('warns for an unknown tag in export rules', () => {
         // Arrange
         const testConfig = {
+            path: 'testPath',
             exports: [
                 {
                     modules: 'testModule',
@@ -90,13 +91,14 @@ describe('validateTagsExist', () => {
         // Assert
         expect(result.reportWarning).toHaveBeenCalledWith(
             "Tag 'unknownTag' is referred to but is not defined in any fence.",
-            testConfig
+            testConfig.path
         );
     });
 
     it('warns for an unknown tag in dependency rules', () => {
         // Arrange
         const testConfig = {
+            path: 'testPath',
             dependencies: [
                 {
                     dependency: 'test-dependency',
@@ -113,13 +115,14 @@ describe('validateTagsExist', () => {
         // Assert
         expect(result.reportWarning).toHaveBeenCalledWith(
             "Tag 'unknownTag' is referred to but is not defined in any fence.",
-            testConfig
+            testConfig.path
         );
     });
 
     it('warns for an unknown tag in import rules', () => {
         // Arrange
         const testConfig = {
+            path: 'testPath',
             imports: ['unknownTag'],
         };
 
@@ -131,7 +134,7 @@ describe('validateTagsExist', () => {
         // Assert
         expect(result.reportWarning).toHaveBeenCalledWith(
             "Tag 'unknownTag' is referred to but is not defined in any fence.",
-            testConfig
+            testConfig.path
         );
     });
 


### PR DESCRIPTION
Good-fences will crash if, for instance, the `exports` property is not an array.  I added some validation for that.  I also added some sanity checks like if someone used `export` instead of `exports`.