### PR TITLE
Consider any import outside rootDir external (Issue 75)

### DIFF
--- a/src/core/ImportRecord.ts
+++ b/src/core/ImportRecord.ts
@@ -2,6 +2,7 @@ import NormalizedPath from '../types/NormalizedPath';
 import TypeScriptProgram from './TypeScriptProgram';
 import normalizePath from '../utils/normalizePath';
 import * as path from 'path';
+import getOptions from '../utils/getOptions';
 
 export default class ImportRecord {
     public filePath: NormalizedPath;
@@ -17,8 +18,8 @@ export default class ImportRecord {
         }
     }
 
-    // Is this import an external dependency (i.e. is it under node_modules)?
+    // Is this import an external dependency (i.e. is it under node_modules or outside the rootPath)?
     get isExternal() {
-        return this.filePath.split(path.sep).indexOf('node_modules') != -1;
+        return this.filePath.split(path.sep).indexOf('node_modules') != -1 || !this.filePath.startsWith(getOptions().rootDir);
     }
 }

--- a/src/core/ImportRecord.ts
+++ b/src/core/ImportRecord.ts
@@ -18,8 +18,12 @@ export default class ImportRecord {
         }
     }
 
-    // Is this import an external dependency (i.e. is it under node_modules or outside the rootPath)?
+    // Is this import an external dependency (i.e. is it under node_modules or outside the rootDir)?
     get isExternal() {
-        return this.filePath.split(path.sep).indexOf('node_modules') != -1 || !this.filePath.startsWith(getOptions().rootDir);
+        let isInNodeModules = this.filePath.split(path.sep).indexOf('node_modules') != -1;
+        let isUnderRootFolder = this.filePath.startsWith(getOptions().rootDir);
+        let isLocalRelativePath = this.filePath.startsWith('./');
+        let isExternalPath = !isUnderRootFolder && !isLocalRelativePath;
+        return isInNodeModules || isExternalPath;
     }
 }


### PR DESCRIPTION
Using a Rush monorepo, imports from peer projects appear as coming from the local file system and not from node_modules. 

good-fences has a concept of a "rootDir" for the fence check. It seems by definition that anything that is not under that root should also be considered external for the sake of fencing.

This change modifies ImportRecord's isExternal check so that any import that is not under the rootDir is also considered external.