### PR TITLE
Add option to automatically fix import and dependency violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ Default         | CLI                                    | API
 ----------------|----------------------------------------|----
 `process.cwd()` | `--rootDir <string>`<br/>`-r <string>` | `rootDir: string`
 
+### Fix Imports and Dependencies
+
+Fix import and dependency violations automatically instead of printing the violations.
+
+Default         | CLI                                    | API
+----------------|----------------------------------------|----
+`false`| `--fixImportsAndDependencies `<br/>`-f` | `fixImportsAndDependencies: boolean`
+
 ## Return value
 
 When running good-fences via the API, the results are returned in a structure like the following:

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -10,6 +10,7 @@ const options = commander
     .version(packageVersion)
     .option('-p, --project <string>', 'tsconfig.json file')
     .option('-r, --rootDir <string>', 'root directory of the project')
+    .option('-f, --fixImportsAndDependencies', 'fix import and dependency violations')
     .parse(process.argv) as RawOptions;
 
 // Run good-fences

--- a/src/core/result.ts
+++ b/src/core/result.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import Config from '../types/config/Config';
 import GoodFencesError from '../types/GoodFencesError';
 import GoodFencesResult from '../types/GoodFencesResult';
+import ViolationType from '../types/ViolationType';
 import ImportRecord from './ImportRecord';
 
 const result: GoodFencesResult = {
@@ -17,7 +18,8 @@ export function reportViolation(
     message: string,
     sourceFile: string,
     importRecord: ImportRecord,
-    config: Config
+    config: Config,
+    violationType: ViolationType,
 ) {
     let fencePath = config.path + path.sep + 'fence.json';
 
@@ -32,6 +34,7 @@ export function reportViolation(
         rawImport: importRecord.rawImport,
         fencePath,
         detailedMessage,
+        violationType,
     };
 
     result.errors.push(error);

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -5,6 +5,10 @@ import TypeScriptProgram from './TypeScriptProgram';
 import normalizePath from '../utils/normalizePath';
 import { getResult } from './result';
 import { validateTagsExist } from '../validation/validateTagsExist';
+import GoodFencesError from '../types/GoodFencesError';
+import { ViolationType } from '../types/ViolationType';
+import GoodFencesResult from '../types/GoodFencesResult';
+import { readFileSync, writeFileSync } from 'fs';
 
 export function run(rawOptions: RawOptions) {
     // Store options so they can be globally available
@@ -20,5 +24,53 @@ export function run(rawOptions: RawOptions) {
         validateFile(normalizePath(file), tsProgram);
     });
 
-    return getResult();
+    if (getOptions().fixImportsAndDependencies) {
+        fixImportsAndDependencies(getResult());
+    } else {
+        return getResult();
+    }
+}
+
+function fixImportsAndDependencies(result: GoodFencesResult) {
+    // initialResults is a map of fence file path (string) => violations ({import: string, violationType: ViolationType}) for that fence file
+    const initialResults: { [key: string] : Violation[] } = {};
+    const reducedResults = result.errors.reduce(reduceErrorsToMap, initialResults);
+
+    Object.keys(reducedResults).forEach(fenceFile => {
+        const config = JSON.parse(readFileSync(fenceFile).toString());
+        // add imports to the imports section
+        const importViolations = reducedResults[fenceFile].filter(violation => violation.violationType === ViolationType.Import).map(violation => violation.import);
+        config.imports = (config.imports || []).concat(...importViolations);
+        config.imports = config.imports.sort();
+
+        // add dependencies to the dependencies section
+        const dependencyViolations = reducedResults[fenceFile].filter(violation => violation.violationType === ViolationType.Dependency).map(violation => violation.import);
+        config.dependencies = (config.dependencies || []).concat(...dependencyViolations);
+        config.dependencies = config.dependencies.sort();
+
+        writeFileSync(fenceFile, JSON.stringify(config, null, 2));
+    })
+}
+
+interface Violation {
+    import: string;
+    violationType: ViolationType;
+}
+
+function reduceErrorsToMap(total: { [key: string] : Violation[] }, currentValue: GoodFencesError): { [key: string] : Violation[] } {
+    const fence = currentValue.fencePath;
+    if (!total[fence]) {
+        total[fence] = [];
+    }
+
+    const existingMatches = total[fence].filter(violation => violation.import === currentValue.rawImport && violation.violationType === currentValue.violationType);
+
+    if (existingMatches.length == 0) {
+        total[fence].push({
+            import: currentValue.rawImport,
+            violationType: currentValue.violationType
+        });
+    }
+
+    return total;
 }

--- a/src/types/GoodFencesError.ts
+++ b/src/types/GoodFencesError.ts
@@ -1,7 +1,10 @@
+import ViolationType from './ViolationType';
+
 export default interface GoodFencesError {
     message: string;
     sourceFile?: string;
     rawImport?: string;
     fencePath: string;
     detailedMessage: string;
+    violationType?: ViolationType;
 };

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -3,5 +3,6 @@ import NormalizedPath from './NormalizedPath';
 export default interface Options {
     project: NormalizedPath;
     rootDir: NormalizedPath;
+    fixImportsAndDependencies: boolean;
     ignoreExternalFences: boolean;
 }

--- a/src/types/RawOptions.ts
+++ b/src/types/RawOptions.ts
@@ -1,5 +1,6 @@
 export default interface RawOptions {
     project?: string;
     rootDir?: string;
+    fixImportsAndDependencies?: boolean;
     ignoreExternalFences?: boolean;
 }

--- a/src/types/ViolationType.ts
+++ b/src/types/ViolationType.ts
@@ -1,0 +1,7 @@
+export enum ViolationType {
+    Module = 0,
+    Import,
+    Dependency
+}
+
+export default ViolationType;

--- a/src/utils/getOptions.ts
+++ b/src/utils/getOptions.ts
@@ -18,6 +18,7 @@ export function setOptions(rawOptions: RawOptions) {
     options = {
         project,
         rootDir,
+        fixImportsAndDependencies: rawOptions.fixImportsAndDependencies,
         ignoreExternalFences: rawOptions.ignoreExternalFences,
     };
 }

--- a/src/validation/validateDependencyRules.ts
+++ b/src/validation/validateDependencyRules.ts
@@ -4,6 +4,7 @@ import getConfigsForFile from '../utils/getConfigsForFile';
 import { reportViolation } from '../core/result';
 import ImportRecord from '../core/ImportRecord';
 import fileHasNecessaryTag from '../utils/fileHasNecessaryTag';
+import ViolationType from '../types/ViolationType';
 const minimatch = require('minimatch');
 
 export default function validateDependencyRules(
@@ -38,5 +39,5 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord
     }
 
     // If we made it here, we didn't find a rule that allows the dependency
-    reportViolation('Dependency is not allowed', sourceFile, importRecord, config);
+    reportViolation('Dependency is not allowed', sourceFile, importRecord, config, ViolationType.Dependency);
 }

--- a/src/validation/validateExportRules.ts
+++ b/src/validation/validateExportRules.ts
@@ -6,6 +6,7 @@ import fileMatchesConfigGlob from '../utils/fileMatchesConfigGlob';
 import fileHasNecessaryTag from '../utils/fileHasNecessaryTag';
 import { reportViolation } from '../core/result';
 import ImportRecord from '../core/ImportRecord';
+import ViolationType from '../types/ViolationType';
 
 export default function validateExportRules(
     sourceFile: NormalizedPath,
@@ -34,7 +35,7 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord
     }
 
     // If we made it here, the import is invalid
-    reportViolation('Module is not exported', sourceFile, importRecord, config);
+    reportViolation('Module is not exported', sourceFile, importRecord, config, ViolationType.Module);
 }
 
 function hasMatchingExport(config: Config, sourceFile: NormalizedPath, importFile: NormalizedPath) {

--- a/src/validation/validateImportRules.ts
+++ b/src/validation/validateImportRules.ts
@@ -5,6 +5,7 @@ import getConfigsForFile from '../utils/getConfigsForFile';
 import { reportViolation } from '../core/result';
 import ImportRecord from '../core/ImportRecord';
 import getTagsForFile from '../utils/getTagsForFile';
+import ViolationType from '../types/ViolationType';
 
 export default function validateImportRules(
     sourceFile: NormalizedPath,
@@ -39,5 +40,5 @@ function validateConfig(config: Config, sourceFile: NormalizedPath, importRecord
     }
 
     // If we made it here, the import is invalid
-    reportViolation('Import not allowed', sourceFile, importRecord, config);
+    reportViolation('Import not allowed', sourceFile, importRecord, config, ViolationType.Import);
 }


### PR DESCRIPTION
Adding an optional flag `--fixImportsAndDependencies` to allow good-fences to fix errors for you instead of just printing out what those errors are.

This only fixes import and dependency errors- we don't try to automatically fix export errors, as those are more strict and should require manual changing for now, and we don't try to fix any tags.