### PR TITLE
Allow for tags to be applicable to only certain files

### DIFF
--- a/sample/src/componentA/fence.json
+++ b/sample/src/componentA/fence.json
@@ -9,5 +9,5 @@
             "accessibleTo": "unknownTag"
         }
     ],
-    "imports": []
+    "imports": ["utils-only-for-a"]
 }

--- a/sample/src/componentA/helperA2.ts
+++ b/sample/src/componentA/helperA2.ts
@@ -1,1 +1,7 @@
-export default function helperA2() {}
+import { util1 } from "../utils/util1"; // INVALID IMPORT
+import { util2ForA } from "../utils/util2.forA";
+
+export default function helperA2() {
+  util1();
+  util2ForA();
+}

--- a/sample/src/componentB/fence.json
+++ b/sample/src/componentB/fence.json
@@ -7,5 +7,6 @@
             "modules": "componentB",
             "accessibleTo": "tagA"
         }
-    ]
+    ],
+    "imports": ["utils"]
 }

--- a/sample/src/componentB/helperB1.ts
+++ b/sample/src/componentB/helperB1.ts
@@ -1,1 +1,7 @@
-export default function helperB1() {}
+import { util1 } from "../utils/util1";
+import { util2ForA } from "../utils/util2.forA";
+
+export default function helperB1() {
+  util1();
+  util2ForA();
+}

--- a/sample/src/utils/fence.json
+++ b/sample/src/utils/fence.json
@@ -1,0 +1,9 @@
+{
+  "tags": [
+      "utils",
+      {
+        "applicableTo": "*.forA.*",
+        "tag": "utils-only-for-a"
+      }
+  ]
+}

--- a/sample/src/utils/util1.ts
+++ b/sample/src/utils/util1.ts
@@ -1,0 +1,1 @@
+export function util1(): void {}

--- a/sample/src/utils/util2.forA.ts
+++ b/sample/src/utils/util2.forA.ts
@@ -1,0 +1,1 @@
+export function util2ForA(): void {}

--- a/src/types/config/Config.ts
+++ b/src/types/config/Config.ts
@@ -1,10 +1,11 @@
 import NormalizedPath from '../NormalizedPath';
 import DependencyRule from './DependencyRule';
 import ExportRule from './ExportRule';
+import TagRule from './TagRule';
 
 export default interface Config {
     path: NormalizedPath;
-    tags: string[];
+    tags: TagRule[];
     exports: ExportRule[];
     dependencies: DependencyRule[];
     imports: string[];

--- a/src/types/config/TagRule.ts
+++ b/src/types/config/TagRule.ts
@@ -1,0 +1,4 @@
+export default interface TagRule {
+  applicableTo: string[] | null;
+  tag: string;
+};

--- a/src/types/rawConfig/RawConfig.ts
+++ b/src/types/rawConfig/RawConfig.ts
@@ -1,8 +1,9 @@
 import RawDependencyRule from './RawDependencyRule';
 import RawExportRule from './RawExportRule';
+import RawTagRule from './RawTagRule';
 
 export default interface RawConfig {
-    tags?: string[];
+    tags?: RawTagRule[];
     exports?: RawExportRule[];
     dependencies?: RawDependencyRule[];
     imports?: string[];

--- a/src/types/rawConfig/RawTagRule.ts
+++ b/src/types/rawConfig/RawTagRule.ts
@@ -1,0 +1,7 @@
+interface AdvancedRawTagRule {
+  applicableTo: string | string[];
+  tag: string;
+}
+
+type RawTagRule = AdvancedRawTagRule | string;
+export default RawTagRule;

--- a/src/utils/getFilePathRelativeToConfig.ts
+++ b/src/utils/getFilePathRelativeToConfig.ts
@@ -1,0 +1,22 @@
+import * as path from 'path';
+import Config from '../types/config/Config';
+import NormalizedPath from '../types/NormalizedPath';
+
+export default function getFilePathRelativeToConfig(filePath: NormalizedPath, config: Config): NormalizedPath {
+  // If the provided path doesn't start with the config directory, then return
+  // the absolute path.
+  const lowercasePath = filePath.toLowerCase();
+  if (!lowercasePath.startsWith(config.path.toLowerCase())) {
+    return filePath;
+  }
+
+  let startIndex = config.path.length;
+
+  // Remove the leading path separator from the relative path, if removing the
+  // config directory path would leave it
+  if (filePath[startIndex] === path.sep) {
+    startIndex += path.sep.length;
+  }
+
+  return <NormalizedPath>filePath.substr(startIndex);
+}

--- a/src/utils/getTagsForFile.ts
+++ b/src/utils/getTagsForFile.ts
@@ -1,5 +1,8 @@
 import NormalizedPath from '../types/NormalizedPath';
 import getConfigsForFile from './getConfigsForFile';
+import getFilePathRelativeToConfig from './getFilePathRelativeToConfig';
+const minimatch = require('minimatch');
+
 
 export default function getTagsForFile(filePath: NormalizedPath): string[] {
     let configs = getConfigsForFile(filePath);
@@ -7,8 +10,26 @@ export default function getTagsForFile(filePath: NormalizedPath): string[] {
 
     configs.forEach(config => {
         if (config.tags) {
+            const relativeFilePath = getFilePathRelativeToConfig(filePath, config);
+
             config.tags.forEach(tag => {
-                tags[tag] = true;
+                let isApplicable: boolean;
+
+                if (tag.applicableTo === null) {
+                    // If this tag doesn't specify specific paths it is applicable,
+                    // it's applicable to every file in the tree.
+                    isApplicable = true;
+                } else {
+                    // If this file matches ANY of the glob patterns specified for
+                    // the tag, then it receives the tag.
+                    isApplicable = tag.applicableTo.some(
+                        applicablePath => minimatch(relativeFilePath, applicablePath)
+                    );
+                }
+
+                if (isApplicable) {
+                    tags[tag.tag] = true;
+                }
             });
         }
     });

--- a/src/validation/validateTagsExist.ts
+++ b/src/validation/validateTagsExist.ts
@@ -12,7 +12,7 @@ export function validateTagsExist() {
 
         if (config.tags) {
             for (const tag of config.tags) {
-                allTags.add(tag);
+                allTags.add(tag.tag);
             }
         }
     }

--- a/test/endToEnd/endToEndTests.expected.json
+++ b/test/endToEnd/endToEndTests.expected.json
@@ -14,6 +14,12 @@
         },
         {
             "message": "Import not allowed",
+            "sourceFile": "sample/src/componentA/helperA2.ts",
+            "rawImport": "../utils/util1",
+            "fencePath": "sample/src/componentA/fence.json"
+        },
+        {
+            "message": "Import not allowed",
             "sourceFile": "sample/src/componentA/componentA.ts",
             "rawImport": "../componentB/componentB",
             "fencePath": "sample/src/componentA/fence.json"

--- a/test/utils/getTagsForFileTests.ts
+++ b/test/utils/getTagsForFileTests.ts
@@ -1,0 +1,162 @@
+jest.mock('../../src/utils/getConfigsForFile');
+
+import NormalizedPath from '../../src/types/NormalizedPath';
+import Config from '../../src/types/config/Config';
+import { default as gcff } from '../../src/utils/getConfigsForFile';
+import getTagsForFile from '../../src/utils/getTagsForFile';
+
+const getConfigsForFile: jest.Mock<Config[]> = gcff as any;
+
+const DIRECTORY_A = <NormalizedPath>'/home/admin/good-fences';
+
+const FILEPATH_A = <NormalizedPath>`${DIRECTORY_A}/a.txt`;
+const FILEPATH_B = <NormalizedPath>`${DIRECTORY_A}/b.txt`;
+
+describe('getTagsForTest', () => {
+  beforeEach(() => {
+    getConfigsForFile.mockReset();
+  });
+
+  it('should return an empty array for files without configs', () => {
+    getConfigsForFile.mockReturnValue([]);
+
+    const tags = getTagsForFile(FILEPATH_A);
+
+    expect(tags).toHaveLength(0);
+  });
+
+  it('should skip over config file that don\'t define any tags', () => {
+    getConfigsForFile.mockReturnValue([{
+      path: DIRECTORY_A,
+      tags: null,
+      exports: null,
+      dependencies: null,
+      imports: null
+    }]);
+
+    const tags = getTagsForFile(FILEPATH_A);
+
+    expect(tags).toHaveLength(0);
+  });
+
+  it('should alphabetize the tags returned', () => {
+    getConfigsForFile.mockReturnValue([
+      {
+        path: DIRECTORY_A,
+        tags: [{
+          applicableTo: null,
+          tag: 'zzzz'
+        },{
+          applicableTo: null,
+          tag: 'aaaa'
+        }],
+        exports: null,
+        dependencies: null,
+        imports: null
+      }
+    ]);
+
+    const tags = getTagsForFile(FILEPATH_A);
+
+    expect(tags).toEqual(['aaaa', 'zzzz']);
+  });
+
+  it('should remove duplicated tags', () => {
+    getConfigsForFile.mockReturnValue([
+      {
+        path: DIRECTORY_A,
+        tags: [{
+          applicableTo: null,
+          tag: 'hello'
+        },{
+          applicableTo: null,
+          tag: 'hello'
+        }],
+        exports: null,
+        dependencies: null,
+        imports: null
+      }
+    ]);
+
+    const tags = getTagsForFile(FILEPATH_A);
+
+    expect(tags).toEqual(['hello']);
+  });
+
+  it('should include all globally-applicable tags defined for all config files', () => {
+    getConfigsForFile.mockReturnValue([
+      {
+        path: DIRECTORY_A,
+        tags: [{
+          applicableTo: null,
+          tag: 'hello'
+        },{
+          applicableTo: null,
+          tag: 'world'
+        }],
+        exports: null,
+        dependencies: null,
+        imports: null
+      },
+      {
+        path: DIRECTORY_A,
+        tags: [{
+          applicableTo: null,
+          tag: 'goodbye'
+        }],
+        exports: null,
+        dependencies: null,
+        imports: null
+      }
+    ]);
+
+    const tags = getTagsForFile(FILEPATH_A);
+
+    expect(tags).toEqual(['goodbye', 'hello', 'world']);
+  });
+
+  it('should should respect tag applicability, if defined', () => {
+    getConfigsForFile.mockReturnValue([
+      {
+        path: DIRECTORY_A,
+        tags: [{
+          applicableTo: ['a.txt'],
+          tag: 'a-files'
+        },{
+          applicableTo: ['b.txt'],
+          tag: 'b-files'
+        }],
+        exports: null,
+        dependencies: null,
+        imports: null
+      }
+    ]);
+
+    const aTags = getTagsForFile(FILEPATH_A);
+    const bTags = getTagsForFile(FILEPATH_B);
+
+    expect(aTags).toEqual(['a-files']);
+    expect(bTags).toEqual(['b-files'])
+  });
+
+  it('should should allow for glob patterns relative to the config directory', () => {
+    getConfigsForFile.mockReturnValue([
+      {
+        path: DIRECTORY_A,
+        tags: [{
+          applicableTo: ['**/*.log'],
+          tag: 'logs'
+        }],
+        exports: null,
+        dependencies: null,
+        imports: null
+      }
+    ]);
+
+    const logTags = getTagsForFile(<NormalizedPath>`${DIRECTORY_A}/some/nested/directory/my.log`);
+    const jsonTags = getTagsForFile(<NormalizedPath>`${DIRECTORY_A}/some/nested/directory/my.json`);
+
+    expect(logTags).toEqual(['logs']);
+    expect(jsonTags).toEqual([]);
+  });
+});

--- a/test/utils/loadConfigTests.ts
+++ b/test/utils/loadConfigTests.ts
@@ -3,6 +3,8 @@ import RawConfig from '../../src/types/rawConfig/RawConfig';
 import loadConfig, { normalizeExportRules } from '../../src/utils/loadConfig';
 import * as normalizePath from '../../src/utils/normalizePath';
 import ConfigSet from '../../src/types/ConfigSet';
+import RawTagRule from '../../src/types/rawConfig/RawTagRule';
+import TagRule from '../../src/types/config/TagRule';
 
 describe('loadConfig', () => {
     const configPath = 'configPath';
@@ -40,24 +42,32 @@ describe('loadConfig', () => {
         expect(configSet[normalizedPath].path).toBe(normalizedPath);
     });
 
-    it('includes the tags', () => {
+    it('normalizes the tag rules', () => {
         // Arrange
-        let tags = ['tag1', 'tag2'];
+        let tags: RawTagRule[] = [
+            'tag1',
+            {
+                applicableTo: '**/*',
+                tag: 'tag2'
+            },
+            {
+                applicableTo: ['*.a', '*.b'],
+                tag: 'tag3'
+            }
+        ];
         rawConfig = { tags };
+
+        let normalizedTags: TagRule[] = [
+            { applicableTo: null, tag: 'tag1' },
+            { applicableTo: ['**/*'], tag: 'tag2' },
+            { applicableTo: ['*.a', '*.b'], tag: 'tag3' }
+        ];
 
         // Act
         loadConfig(configPath, configSet);
 
         // Assert
-        expect(configSet[normalizedPath].tags).toHaveLength(2);
-        expect(configSet[normalizedPath].tags[0]).toEqual({
-            applicableTo: null,
-            tag: tags[0]
-        });
-        expect(configSet[normalizedPath].tags[1]).toEqual({
-            applicableTo: null,
-            tag: tags[1]
-        });
+        expect(configSet[normalizedPath].tags).toEqual(normalizedTags);
     });
 
     it('includes the imports', () => {

--- a/test/utils/loadConfigTests.ts
+++ b/test/utils/loadConfigTests.ts
@@ -49,7 +49,15 @@ describe('loadConfig', () => {
         loadConfig(configPath, configSet);
 
         // Assert
-        expect(configSet[normalizedPath].tags).toBe(tags);
+        expect(configSet[normalizedPath].tags).toHaveLength(2);
+        expect(configSet[normalizedPath].tags[0]).toEqual({
+            applicableTo: null,
+            tag: tags[0]
+        });
+        expect(configSet[normalizedPath].tags[1]).toEqual({
+            applicableTo: null,
+            tag: tags[1]
+        });
     });
 
     it('includes the imports', () => {

--- a/test/validation/validateTagsExistTests.ts
+++ b/test/validation/validateTagsExistTests.ts
@@ -138,13 +138,22 @@ describe('validateTagsExist', () => {
         );
     });
 
-    function initializeAllConfigs(testConfig: any) {
+    function initializeAllConfigs(testConfig: any): void {
         allConfigs = {
             config1: {
-                tags: ['tag1', 'tag2'],
+                tags: [{
+                    applicableTo: null,
+                    tag: 'tag1'
+                }, {
+                    applicableTo: null,
+                    tag: 'tag2'
+                }],
             },
             config2: {
-                tags: ['tag3'],
+                tags: [{
+                    applicableTo: null,
+                    tag: 'tag3'
+                }],
             },
             testConfig,
         } as any;


### PR DESCRIPTION
### Description

Currently, `tags` are universally applicable to all files in the tree of the **fence.json** file. This works well for smaller projects or for repositories that make use of directories, but can be limiting for flatter directory hierarchies. Since `imports` and `exports` are powered off of tags, it can be problematic when you want to permit the importing of one or two select files, without allowing the entire directory.

For example:
```
src/
  application-1/
    fence.json     <— Good with importing anything from shared

  components/
    fence.json     <— Wants to allow shared/theme.ts, but would require also allowing shared/redux

  shared/
    redux/
      ...

    theme.ts
```

For this, I took the mentality of specifying that certain dependencies were only allowed for specific files, and added the same logic to tags. By default, all string tags operate like they did — globally applicable to the entire tree of the config file. But you can now also specify them as an object, providing a glob path/paths to allow for tagging only specific files:
```
{
  "tags": [
      "shared",
      {
        "applicableTo": "theme.ts",
        "tag": "theme"
      }
  ]
}
```

Doing this, **components/** could now just import **shared/theme.ts** — it will still be an error to import **shared/redux**.

## Testing

I've updated the unit tests and wrote some new ones concerning tag resolution and how `getTagsForFile` works. I've also updated the sample application to showcase an example of this.

## Areas of Concern

Primarily, I'd want to make sure that my logic for applying the glob pattern relative to the directory the config file was defined in makes sense. Programmatically it runs, but it might make some assumptions that I'd like to make sure are actually valid.

Also, let me know if there are any stylistic or formatting issues.