### PR TITLE
Allow for multiple root directories when scanning for fence files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,8 @@
 node_modules/
 src/
 sample/
+.github/
 .vscode
-.travis.yml
 jest.*
 tsconfig.json
 yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "good-fences",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "description": "Code boundary management for TypeScript projects",
     "main": "./lib/index.js",
     "typings": "./lib/index.d.ts",

--- a/src/core/ImportRecord.ts
+++ b/src/core/ImportRecord.ts
@@ -21,7 +21,7 @@ export default class ImportRecord {
     // Is this import an external dependency (i.e. is it under node_modules or outside the rootDir)?
     get isExternal() {
         let isInNodeModules = this.filePath.split(path.sep).indexOf('node_modules') != -1;
-        let isUnderRootFolder = this.filePath.startsWith(getOptions().rootDir);
+        let isUnderRootFolder = getOptions().rootDir.some(rootDir => this.filePath.startsWith(rootDir));
         let isLocalRelativePath = this.filePath.startsWith('./');
         let isExternalPath = !isUnderRootFolder && !isLocalRelativePath;
         return isInNodeModules || isExternalPath;

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -2,6 +2,6 @@ import NormalizedPath from './NormalizedPath';
 
 export default interface Options {
     project: NormalizedPath;
-    rootDir: NormalizedPath;
+    rootDir: NormalizedPath[];
     ignoreExternalFences: boolean;
 }

--- a/src/types/RawOptions.ts
+++ b/src/types/RawOptions.ts
@@ -1,5 +1,5 @@
 export default interface RawOptions {
     project?: string;
-    rootDir?: string;
+    rootDir?: string | string[];
     ignoreExternalFences?: boolean;
 }

--- a/src/utils/getAllConfigs.ts
+++ b/src/utils/getAllConfigs.ts
@@ -11,7 +11,11 @@ export default function getAllConfigs(): ConfigSet {
         configSet = {};
 
         let files: string[] = [];
-        accumulateFences(getOptions().rootDir, files, getOptions().ignoreExternalFences);
+        const rootDirOption = getOptions().rootDir;
+        const rootDirs: string[] = Array.isArray(rootDirOption) ? rootDirOption : [rootDirOption];
+        for (let rootDir of rootDirs) {
+            accumulateFences(rootDir, files, getOptions().ignoreExternalFences);
+        }
 
         files.forEach(file => {
             loadConfig(file, configSet);

--- a/src/utils/getOptions.ts
+++ b/src/utils/getOptions.ts
@@ -1,6 +1,7 @@
-import RawOptions from '../types/RawOptions';
-import Options from '../types/Options';
-import normalizePath from './normalizePath';
+import RawOptions from "../types/RawOptions";
+import Options from "../types/Options";
+import normalizePath from "./normalizePath";
+import NormalizedPath from "../types/NormalizedPath";
 
 let options: Options;
 
@@ -10,10 +11,15 @@ export default function getOptions() {
 
 export function setOptions(rawOptions: RawOptions) {
     // Normalize and apply defaults
-    const rootDir = normalizePath(rawOptions.rootDir || process.cwd());
+    const nonNormalizedRoots: string[] = Array.isArray(rawOptions.rootDir)
+        ? rawOptions.rootDir
+        : [rawOptions.rootDir || process.cwd()];
+    const rootDir: NormalizedPath[] = nonNormalizedRoots.map(
+        (individualRootDirPath: string) => normalizePath(individualRootDirPath)
+    );
     const project = rawOptions.project
         ? normalizePath(rawOptions.project)
-        : normalizePath(rootDir, 'tsconfig.json');
+        : normalizePath(rootDir[0], "tsconfig.json");
 
     options = {
         project,

--- a/src/utils/getOptions.ts
+++ b/src/utils/getOptions.ts
@@ -1,7 +1,7 @@
-import RawOptions from "../types/RawOptions";
-import Options from "../types/Options";
-import normalizePath from "./normalizePath";
-import NormalizedPath from "../types/NormalizedPath";
+import RawOptions from '../types/RawOptions';
+import Options from '../types/Options';
+import normalizePath from './normalizePath';
+import NormalizedPath from '../types/NormalizedPath';
 
 let options: Options;
 


### PR DESCRIPTION
## Motivation

In owa, we currently rely on excluding the node_modules directory.

This works fine under current usage, but BuildXL by convention stores state in the Out directory, which stores unique logs across multiple runs -- this was causing good-fences to take upwards of 20 minutes on subsequent runs.

By specifying the rootDirs as `packages` and `shared` instead of relying on traversing from the common directory `.`, we speed up good-fences (and avoid transient read errors caused by files being deleted out from under good-fences as it traverses BuildXL's internal state).

## Changes
- changes rootDir to an array of strings
- supports falling back to rootDir: string as an argument for backwords compatibility
- upgrades commander to use variadic arguments to support rootDir from the cli
