### PR TITLE
Handle extensionless files in removeFileExtension

### DIFF
--- a/src/utils/fileMatchesConfigGlob.ts
+++ b/src/utils/fileMatchesConfigGlob.ts
@@ -21,5 +21,5 @@ export default function fileMatchesConfigGlob(
 function removeFileExtension(filePath: NormalizedPath): NormalizedPath {
     // Special case for .d.ts files
     let extension = filePath.endsWith('.d.ts') ? '.d.ts' : path.extname(filePath);
-    return <NormalizedPath>filePath.slice(0, -extension.length);
+    return <NormalizedPath>filePath.slice(0, filePath.length - extension.length);
 }


### PR DESCRIPTION
When files don't have an exension, splice is called with (0, -0), whcih
always resolves to ''.

This fixes this so that extensionless files never have their basename
stripped