### PR TITLE
Make fences optional when reporting warnings

### DIFF
--- a/src/core/result.ts
+++ b/src/core/result.ts
@@ -52,9 +52,12 @@ export function reportConfigError(message: string, configPath: string) {
     result.errors.push(error);
 }
 
-export function reportWarning(message: string, configPath: string) {
+export function reportWarning(message: string, configPath?: string) {
     let fencePath = configPath + path.sep + 'fence.json';
-    let detailedMessage = `Good-fences warning: ${message}\n` + `    Fence: ${fencePath}`;
+    let detailedMessage = `Good-fences warning: ${message}\n`;
+    if (configPath) {
+        detailedMessage += `    Fence: ${fencePath}`;
+    }
 
     const warning: GoodFencesError = {
         message,

--- a/src/types/GoodFencesError.ts
+++ b/src/types/GoodFencesError.ts
@@ -2,6 +2,6 @@ export default interface GoodFencesError {
     message: string;
     sourceFile?: string;
     rawImport?: string;
-    fencePath: string;
+    fencePath?: string;
     detailedMessage: string;
 }


### PR DESCRIPTION
This is because when running as a git commit hook we frequently run into
issues that we want to report to the user but do not want to fail the
build, which are not associated with a specific build.

For example:
- As part of incremental checks, we impose a maximum file limit
  so that the incremental check on commits (e.g. large merges) does
  not run for multiple minutes. This leaves open the option to opt into
  a full check without blocking commits.
  When the incremental check would exceed the maximum check limit, we
  want to warn the user that the check is not happening, but not exit
  with 1, as it would fail precommit hooks.
- When a partial check cannot be calculated from git, we abort early and
  do not perform checks for the same reason as above
- When performing partial checks but there are no changes from
  git in source or fence files, we skip validation. We want to warn
  users about this because they may be running the program manually and
  not running it over the set of files they think they are running it
  over.