### PR TITLE
Omit BOM before parsing JSON configuration file content

### DIFF
--- a/src/utils/loadConfig.ts
+++ b/src/utils/loadConfig.ts
@@ -15,6 +15,10 @@ export function loadConfigFromString(
     configPath: NormalizedPath,
     fileContent: string
 ): Config | null {
+    // Strip BOM if needed
+    if (fileContent.charCodeAt(0) === 0xfeff) {
+        fileContent = fileContent.slice(1);
+    }
     // Load the raw config
     let rawConfig: RawConfig = JSON.parse(fileContent);
 

--- a/test/utils/loadConfigTests.ts
+++ b/test/utils/loadConfigTests.ts
@@ -13,7 +13,7 @@ describe('loadConfig', () => {
     let configSet: ConfigSet;
 
     beforeEach(() => {
-        spyOn(fs, 'readFileSync').and.returnValue({});
+        spyOn(fs, 'readFileSync').and.returnValue('');
         spyOn(JSON, 'parse').and.callFake(() => rawConfig);
         spyOn(normalizePath, 'default').and.returnValue(normalizedPath);
         configSet = {};


### PR DESCRIPTION
Problem:
When configuration files include the UTF8 BOM, `JSON.parse` fails.

Fix:
Omit first character if it's the BOM before parsing.