### PR TITLE
Allow comments in fence.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "nodegit": "^0.27.0",
         "picomatch": "^2.3.0",
         "tsconfig-paths": "^3.10.1",
-        "typescript": "^4.0.3"
+        "typescript": "^4.0.3",
+        "strip-json-comments": "^3.1.1"
     },
     "devDependencies": {
         "@types/cli-progress": "^3.9.2",

--- a/src/utils/loadConfig.ts
+++ b/src/utils/loadConfig.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import stripJsonComments from 'strip-json-comments';
 import RawConfig from '../types/rawConfig/RawConfig';
 import Config from '../types/config/Config';
 import normalizePath from './normalizePath';
@@ -19,6 +20,9 @@ export function loadConfigFromString(
     if (fileContent.charCodeAt(0) === 0xfeff) {
         fileContent = fileContent.slice(1);
     }
+
+    fileContent = stripJsonComments(fileContent);
+
     // Load the raw config
     let rawConfig: RawConfig = JSON.parse(fileContent);
 

--- a/test/utils/loadConfigTests.ts
+++ b/test/utils/loadConfigTests.ts
@@ -1,9 +1,11 @@
 jest.mock('fs');
 import * as fs from 'fs';
 import RawConfig from '../../src/types/rawConfig/RawConfig';
-import loadConfig, { normalizeExportRules } from '../../src/utils/loadConfig';
+import loadConfig, { loadConfigFromString, normalizeExportRules } from '../../src/utils/loadConfig';
 import * as normalizePath from '../../src/utils/normalizePath';
 import ConfigSet from '../../src/types/ConfigSet';
+import Config from '../../src/types/config/Config';
+import NormalizedPath from '../../src/types/NormalizedPath';
 
 describe('loadConfig', () => {
     const configPath = 'configPath';
@@ -87,6 +89,46 @@ describe('loadConfig', () => {
 
         // Assert
         expect(configSet[normalizedPath].dependencies).toEqual(normalizedDependencies);
+    });
+});
+
+describe('loadConfigFromString', () => {
+    const normalizedPath: NormalizedPath = 'normalizedPath' as NormalizedPath;
+
+    it('handles BOM', () => {
+        // Arrange
+        const configString = '\ufeff{}';
+
+        // Act
+        const config = loadConfigFromString(normalizedPath, configString);
+
+        // Assert
+        const expected: Config = {
+            path: normalizedPath,
+            tags: undefined,
+            exports: null,
+            dependencies: null,
+            imports: undefined,
+        };
+        expect(config).toEqual(expected);
+    });
+
+    it('handles comments', () => {
+        // Arrange
+        const configString = '{} // Comment';
+
+        // Act
+        const config = loadConfigFromString(normalizedPath, configString);
+
+        // Assert
+        const expected: Config = {
+            path: normalizedPath,
+            tags: undefined,
+            exports: null,
+            dependencies: null,
+            imports: undefined,
+        };
+        expect(config).toEqual(expected);
     });
 });
 


### PR DESCRIPTION
Add support for `\\` style comments in fence.json files.

Support for this is inspired by eslint (which uses the same library to do it) and typescript (which seems to have its own implementation).

This works well with VS Code (and likely other tools) support for "JSON with comments".

Also included is a unit test for the BOM fix, since that is in the same function and didn't appear to have test coverage.