### PR TITLE
add new excludeFilesPattern option

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,15 @@ Default         | CLI                                                   | API
 `6000`          | `--maxConcurrentFenceJobs <number>`<br/>`-j <number>` | `maxConcurrentFenceJobs: number`
 
 
+### Exclude Files Patten
+
+Specify a pattern for file names that should be excluded from good-fences validation. For example *.test.ts to exclude test files.
+
+Default         | CLI                                                   | API
+----------------|-------------------------------------------------------|----
+`undefined`          | `--excludeFilesPattern <string>`<br/>`-p <string>` | `excludeFilesPattern: string`
+
+
 ## Return value
 
 When running good-fences via the API, the results are returned in a structure like the following:

--- a/sample/src/componentA/helperA1.test.ts
+++ b/sample/src/componentA/helperA1.test.ts
@@ -1,0 +1,5 @@
+import helperB1 from '../componentB/helperB1'; // INVALID IMPORT in regular code, but valid in test code
+
+export default function helperA1() {
+    helperB1();
+}

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -31,6 +31,10 @@ async function main() {
             '-j, --maxConcurrentFenceJobs',
             'Maximum number of concurrent fence jobs to run. Default 6000'
         )
+        .option(
+            '-p, --excludeFilesPattern <string>',
+            'Exclude files matching the pattern from validation'
+        )
         .option('-b, --progressBar', 'Show a progress bar while evaluating fences');
     program.parse(process.argv);
     const options = program.opts() as RawOptions;

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -88,6 +88,17 @@ export async function run(rawOptions: RawOptions) {
         ? getSourceFilesFromPartialCheck(sourceFileProvider, partialCheck)
         : getSourceFilesNormalized(sourceFileProvider));
 
+    if (options.excludeFilesPattern !== undefined) {
+        // A naive string replace to convert the glob pattern to a regex pattern
+        let regexString = options.excludeFilesPattern
+            .replace('\\', '\\\\.')
+            .replace('.', '\\.')
+            .replace('*', '.*?');
+        normalizedFiles = normalizedFiles.filter(
+            fileName => !fileName.match(new RegExp(regexString, 'i'))
+        );
+    }
+
     await runWithConcurrentLimit(
         // we have to limit the concurrent executed promises because
         // otherwise we will open all the files at the same time and

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -15,4 +15,5 @@ export default interface Options {
     // we try to open too many files concurrently.
     maxConcurrentFenceJobs: number;
     progress: boolean;
+    excludeFilesPattern?: string;
 }

--- a/src/types/RawOptions.ts
+++ b/src/types/RawOptions.ts
@@ -7,4 +7,5 @@ export default interface RawOptions {
     looseRootFileDiscovery?: boolean;
     maxConcurrentJobs?: number;
     progressBar?: boolean;
+    excludeFilesPattern?: string;
 }

--- a/src/utils/getOptions.ts
+++ b/src/utils/getOptions.ts
@@ -36,5 +36,6 @@ export function setOptions(rawOptions: RawOptions) {
         looseRootFileDiscovery: rawOptions.looseRootFileDiscovery || false,
         maxConcurrentFenceJobs: rawOptions.maxConcurrentJobs || 6000,
         progress: rawOptions.progressBar || false,
+        excludeFilesPattern: rawOptions.excludeFilesPattern,
     };
 }

--- a/test/endToEnd/endToEndTests.ts
+++ b/test/endToEnd/endToEndTests.ts
@@ -11,6 +11,7 @@ describe('runner', () => {
         // Act
         const actualResults = await run({
             rootDir: './sample',
+            excludeFilesPattern: '*.test.ts',
         });
 
         // Assert
@@ -29,6 +30,7 @@ describe('runner', () => {
         const actualResults = await run({
             rootDir: './sample',
             looseRootFileDiscovery: true,
+            excludeFilesPattern: '*.test.ts',
         });
 
         // Assert


### PR DESCRIPTION
Adding new excludeFilesPattern option, so we can specify to good-fences what files to ignore. For example *.test.ts files.